### PR TITLE
Add testz and a first simple test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ jdk:
 before_install:
   - export PATH=${PATH}:./vendor/bundle
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sbt publish; fi
+  - sbt ++$TRAVIS_SCALA_VERSION scalafmtCheck test:scalafmtCheck scalafmtSbtCheck test:run
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,20 @@
 lazy val scalaz =
   ProjectRef(uri("git:https://github.com/scalaz/scalaz.git#series/8.0.x"), "baseJVM")
 
+val testzVersion   = "0.0.4"
+val monocleVersion = "1.5.0"
+
 lazy val root = project
   .in(file("."))
   .settings(
     name := "scalaz-schema",
     libraryDependencies ++= Seq(
-      ("com.github.julien-truffaut" %% "monocle-core" % "1.5.0").exclude("org.scalaz", "scalaz")
-    )
+      "com.github.julien-truffaut" %% "monocle-core"  % monocleVersion,
+      "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
+      "org.scalaz"                 %% "testz-core"    % testzVersion % "test",
+      "org.scalaz"                 %% "testz-stdlib"  % testzVersion % "test",
+      "org.scalaz"                 %% "testz-runner"  % testzVersion % "test"
+    ).map(_.exclude("org.scalaz", "scalaz"))
   )
   .dependsOn(scalaz)
 

--- a/src/test/scala/Main.scala
+++ b/src/test/scala/Main.scala
@@ -1,0 +1,49 @@
+package scalaz
+
+package schema
+
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration.Duration
+import scala.concurrent.ExecutionContext.global
+
+import testz._
+import testz.runner._
+
+import scala.Console._
+
+object Main {
+
+  def printReport(scope: List[String], out: Result): List[String] =
+    "\n" :: (out match {
+      case Succeed => Runner.fastConcatDelim(new ::(s"[${GREEN}OK${RESET}]\n", scope), " > ")
+      case fail: Fail =>
+        Runner.fastConcatDelim(new ::(s"[${RED}KO${RESET}]\n", scope), " > ") ++ fail.failures.map {
+          case Left(t)    => t.getMessage
+          case Right(err) => err
+        }
+    })
+
+  val harness: Harness[PureHarness.Uses[Unit]] =
+    PureHarness.toHarness(
+      PureHarness.make(
+        (ls, tr) => Runner.printStrs(printReport(ls, tr), print)
+      )
+    )
+
+  def tests[T](harness: Harness[T]): List[(String, T)] =
+    List(
+      ("Examples", SchemaModuleExamples.tests(harness))
+    )
+
+  def suites(harness: Harness[PureHarness.Uses[Unit]]): List[() => Future[TestOutput]] =
+    tests(harness).map {
+      case (name, suite) =>
+        () => Future.successful(suite((), List(name)))
+    }
+
+  def main(args: Array[String]): Unit = {
+    val result = Await.result(Runner(suites(harness), global), Duration.Inf)
+
+    if (result.failed) throw new Exception("some tests failed")
+  }
+}

--- a/src/test/scala/SchemaModuleExamples.scala
+++ b/src/test/scala/SchemaModuleExamples.scala
@@ -1,0 +1,121 @@
+package scalaz
+
+package schema
+
+import testz._
+import monocle._
+import monocle.macros._
+
+object SchemaModuleExamples {
+
+  val jsonModule = new SchemaModule {
+    type Prim[A]       = JsonSchema.Prim[A]
+    type ProductTermId = String
+    type SumTermId     = String
+  }
+
+  final case class Person(name: String, role: Option[Role])
+  sealed trait Role
+  final case class User(active: Boolean)       extends Role
+  final case class Admin(rights: List[String]) extends Role
+
+  object Person {
+    val name = Getter[Person, String](_.name)
+
+    def setRole(r1: Role): Person => Person = (p: Person) => p.copy(role = Some(r1))
+    val role                                = monocle.Optional[Person, Role](_.role)(setRole(_))
+
+    val user   = GenPrism[Role, User]
+    val admin  = GenPrism[Role, Admin]
+    val active = Getter[User, Boolean](_.active)
+    val rights = Getter[Admin, List[String]](_.rights)
+
+  }
+
+  def tests[T](harness: Harness[T]): T = {
+    import harness._
+    import jsonModule._
+    import jsonModule.Schema._
+
+    section("Manipulating Schemas")(
+      test("Building Schemas using the smart constructors") { () =>
+        val personSchema = record[Person](
+          essentialField[Person, String](
+            "name",
+            prim(JsonSchema.JsonString),
+            Person.name,
+            None
+          ),
+          nonEssentialField[Person, Role](
+            "role",
+            union[Role](
+              branch(
+                "user",
+                record[User](
+                  essentialField("active", prim(JsonSchema.JsonBool), Person.active, None)
+                ),
+                Person.user
+              ),
+              branch(
+                "admin",
+                record[Admin](
+                  essentialField("rights", seq(prim(JsonSchema.JsonString)), Person.rights, None)
+                ),
+                Person.admin
+              )
+            ),
+            Person.role
+          )
+        )
+        val expected =
+          RecordSchema[Person](
+            NonEmptyList.nels(
+              Field.Essential[Person, String](
+                "name",
+                PrimSchema(JsonSchema.JsonString),
+                Person.name,
+                None
+              ),
+              Field.NonEssential[Person, Role](
+                "role",
+                Union(
+                  NonEmptyList.nels(
+                    Branch[Role, User](
+                      "user",
+                      RecordSchema[User](
+                        NonEmptyList.nels(
+                          Field.Essential(
+                            "active",
+                            PrimSchema(JsonSchema.JsonBool),
+                            Person.active,
+                            None
+                          )
+                        )
+                      ),
+                      Person.user
+                    ),
+                    Branch[Role, Admin](
+                      "admin",
+                      RecordSchema[Admin](
+                        NonEmptyList.nels(
+                          Field.Essential(
+                            "rights",
+                            SeqSchema(PrimSchema(JsonSchema.JsonString)),
+                            Person.rights,
+                            None
+                          )
+                        )
+                      ),
+                      Person.admin
+                    )
+                  )
+                ),
+                Person.role
+              )
+            )
+          )
+        assert(personSchema == expected)
+      }
+    )
+  }
+}


### PR DESCRIPTION
Adds the test sources under `src/test/scala`, along with a `Main` that run the tests using testz.

testz  doesn't provide an sbt test framwork, so the `test` task does not run the tests, we need to use `test:run` instead.