### PR TITLE
Add a basic ADT to represent scala's primitive types (#4)

### DIFF
--- a/modules/core/src/main/scala/schemas.scala
+++ b/modules/core/src/main/scala/schemas.scala
@@ -3,7 +3,22 @@ package scalaz
 package schema
 
 object ScalaSchema {
-  type Prim[A] = Nothing
+  type Prim[A] = ScalaPrim[A]
+
+  sealed trait ScalaPrim[A]
+
+  final case object ScalaShort      extends ScalaPrim[Short]
+  final case object ScalaInt        extends ScalaPrim[Int]
+  final case object ScalaLong       extends ScalaPrim[Long]
+  final case object ScalaFloat      extends ScalaPrim[Float]
+  final case object ScalaDouble     extends ScalaPrim[Double]
+  final case object ScalaBigDecimal extends ScalaPrim[BigDecimal]
+  final case object ScalaBype       extends ScalaPrim[Byte]
+  final case object ScalaString     extends ScalaPrim[String]
+  final case object ScalaChar       extends ScalaPrim[Char]
+  final case object ScalaBoolean    extends ScalaPrim[Boolean]
+  final case object ScalaTemporal   extends ScalaPrim[java.time.temporal.Temporal]
+  final case object ScalaUnit       extends ScalaPrim[Unit]
 }
 
 object JsonSchema {

--- a/modules/core/src/main/scala/schemas.scala
+++ b/modules/core/src/main/scala/schemas.scala
@@ -13,7 +13,7 @@ object ScalaSchema {
   final case object ScalaFloat      extends ScalaPrim[Float]
   final case object ScalaDouble     extends ScalaPrim[Double]
   final case object ScalaBigDecimal extends ScalaPrim[BigDecimal]
-  final case object ScalaBype       extends ScalaPrim[Byte]
+  final case object ScalaByte       extends ScalaPrim[Byte]
   final case object ScalaString     extends ScalaPrim[String]
   final case object ScalaChar       extends ScalaPrim[Char]
   final case object ScalaBoolean    extends ScalaPrim[Boolean]


### PR DESCRIPTION
Fixes #4 

As suggested on gitter by @Baccata I took the easy way and just defined an ADT that matches the set of most used Scala primitive types.