### PR TITLE
#22 removing source dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,3 @@
-lazy val scalaz =
-  ProjectRef(
-    uri("git:https://github.com/scalaz/scalaz.git#series/8.0.x"),
-    "baseJVM"
-  )
-
 val testzVersion   = "0.0.4"
 val monocleVersion = "1.5.0"
 
@@ -17,7 +11,6 @@ lazy val root = project
     scalacheck,
     `test-commons`
   )
-  .dependsOn(scalaz)
 
 lazy val core = project
   .in(file("modules/core"))


### PR DESCRIPTION
I think we don't need any scalaz dependency to compile project ATM.
I removed source dependency to let the project build.
Closes #22.