### PR TITLE
Change the module structure so that the Schema ADT has a stable path

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 val testzVersion   = "0.0.4"
 val monocleVersion = "1.5.0"
 
+inThisBuild(scalaVersion := "2.12.8")
+
 lazy val root = project
   .in(file("."))
   .settings(

--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -16,28 +16,31 @@ trait JsonModule[R <: Realisation] extends SchemaModule[R] {
   import Schema._
 
   implicit final def algebra(
-    implicit primNT: R#Prim ~> Encoder,
-    fieldLabel: R#ProductTermId <~< String,
-    branchLabel: R#SumTermId <~< String
-  ): HAlgebra[Schema[R, ?[_], ?], Encoder] = new (Schema[R, Encoder, ?] ~> Encoder) {
+    implicit primNT: R.Prim ~> Encoder,
+    fieldLabel: R.ProductTermId <~< String,
+    branchLabel: R.SumTermId <~< String
+  ): HAlgebra[Schema[R.Prim, R.SumTermId, R.ProductTermId, ?[_], ?], Encoder] =
+    new (Schema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, ?] ~> Encoder) {
 
-    val encloseInBraces         = (s: String) => s"{$s}"
-    def makeField(name: String) = (s: String) => s""""$name":$s"""
+      val encloseInBraces         = (s: String) => s"{$s}"
+      def makeField(name: String) = (s: String) => s""""$name":$s"""
 
-    def apply[A](schema: Schema[R, Encoder, A]): Encoder[A] = schema match {
+      def apply[A](schema: Schema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, A]): Encoder[A] =
+        schema match {
 
-      case PrimSchema(prim)               => primNT(prim)
-      case :*:(left, right)               => (a => left(a._1) + "," + right(a._2))
-      case :+:(left, right)               => (a => a.fold(left, right))
-      case i: IsoSchema[R, Encoder, _, A] => i.base.compose(i.iso.reverseGet)
-      case r: RecordSchema[R, Encoder, A, _] =>
-        encloseInBraces.compose(r.fields).compose(r.iso.reverseGet)
-      case SeqSchema(element)    => (a => a.map(element).mkString("[", ",", "]"))
-      case ProductTerm(id, base) => makeField(fieldLabel(id)).compose(base)
-      case u: Union[R, Encoder, A, _] =>
-        encloseInBraces.compose(u.choices).compose(u.iso.reverseGet)
-      case SumTerm(id, base) => makeField(branchLabel(id)).compose(base)
-      case One()             => (_ => "null")
+          case PrimSchema(prim) => primNT(prim)
+          case :*:(left, right) => (a => left(a._1) + "," + right(a._2))
+          case :+:(left, right) => (a => a.fold(left, right))
+          case i: IsoSchema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, _, A] =>
+            i.base.compose(i.iso.reverseGet)
+          case r: RecordSchema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, A, _] =>
+            encloseInBraces.compose(r.fields).compose(r.iso.reverseGet)
+          case SeqSchema(element)    => (a => a.map(element).mkString("[", ",", "]"))
+          case ProductTerm(id, base) => makeField(fieldLabel(id)).compose(base)
+          case u: Union[R.Prim, R.SumTermId, R.ProductTermId, Encoder, A, _] =>
+            encloseInBraces.compose(u.choices).compose(u.iso.reverseGet)
+          case SumTerm(id, base) => makeField(branchLabel(id)).compose(base)
+          case One()             => (_ => "null")
+        }
     }
-  }
 }

--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -4,34 +4,40 @@ package schema
 
 import Liskov._
 
-trait JsonModule extends SchemaModule {
+object Json {
   type JSON = String
 
   type Encoder[A] = A => JSON
 
+}
+
+trait JsonModule[R <: Realisation] extends SchemaModule[R] {
+  import Json._
   import Schema._
 
   implicit final def algebra(
-    implicit primNT: Prim ~> Encoder,
-    fieldLabel: ProductTermId <~< String,
-    branchLabel: SumTermId <~< String
-  ): HAlgebra[Schema, Encoder] = new (Schema[Encoder, ?] ~> Encoder) {
+    implicit primNT: R#Prim ~> Encoder,
+    fieldLabel: R#ProductTermId <~< String,
+    branchLabel: R#SumTermId <~< String
+  ): HAlgebra[Schema[R, ?[_], ?], Encoder] = new (Schema[R, Encoder, ?] ~> Encoder) {
 
     val encloseInBraces         = (s: String) => s"{$s}"
     def makeField(name: String) = (s: String) => s""""$name":$s"""
 
-    def apply[A](schema: Schema[Encoder, A]): Encoder[A] = schema match {
+    def apply[A](schema: Schema[R, Encoder, A]): Encoder[A] = schema match {
 
-      case PrimSchema(prim)          => primNT(prim)
-      case :*:(left, right)          => (a => left(a._1) + "," + right(a._2))
-      case :+:(left, right)          => (a => a.fold(left, right))
-      case IsoSchema(base, iso)      => base.compose(iso.reverseGet)
-      case RecordSchema(fields, iso) => encloseInBraces.compose(fields).compose(iso.reverseGet)
-      case SeqSchema(element)        => (a => a.map(element).mkString("[", ",", "]"))
-      case ProductTerm(id, base)     => makeField(fieldLabel(id)).compose(base)
-      case Union(choices, iso)       => encloseInBraces.compose(choices).compose(iso.reverseGet)
-      case SumTerm(id, base)         => makeField(branchLabel(id)).compose(base)
-      case One()                     => (_ => "null")
+      case PrimSchema(prim)               => primNT(prim)
+      case :*:(left, right)               => (a => left(a._1) + "," + right(a._2))
+      case :+:(left, right)               => (a => a.fold(left, right))
+      case i: IsoSchema[R, Encoder, _, A] => i.base.compose(i.iso.reverseGet)
+      case r: RecordSchema[R, Encoder, A, _] =>
+        encloseInBraces.compose(r.fields).compose(r.iso.reverseGet)
+      case SeqSchema(element)    => (a => a.map(element).mkString("[", ",", "]"))
+      case ProductTerm(id, base) => makeField(fieldLabel(id)).compose(base)
+      case u: Union[R, Encoder, A, _] =>
+        encloseInBraces.compose(u.choices).compose(u.iso.reverseGet)
+      case SumTerm(id, base) => makeField(branchLabel(id)).compose(base)
+      case One()             => (_ => "null")
     }
   }
 }

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -6,192 +6,208 @@ import monocle.Iso
 
 final case class Fix[F[_[_], _], A](unFix: F[Fix[F, ?], A])
 
-trait SchemaModule {
+trait Realisation {
   type Prim[A]
   type SumTermId
   type ProductTermId
+}
 
-  sealed trait Schema[F[_], A] { //self =>
+sealed trait Schema[R <: Realisation, F[_], A] { //self =>
 
-    def hmap[G[_]](nt: F ~> G): Schema[G, A]
-//    def imap[B](iso: Iso[A, B]): Schema.FSchema[B] = Schema.IsoSchema(self, iso)
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A]
+  //    def imap[B](iso: Iso[A, B]): Schema.FSchema[B] = Schema.IsoSchema(self, iso)
+}
+
+////////////////////
+// The Schema ADT
+////////////////////
+
+// "Essential" nodes. In theory every possible type can be represented using only `One`, `:+:` and `:*:`
+
+final case class One[R <: Realisation, F[_]]() extends Schema[R, F, Unit] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, Unit] = One()
+}
+
+/**
+ * The sum of two schemas, yielding the schema for `A \/ B`
+ */
+final case class :+:[R <: Realisation, F[_], A, B](left: F[A], right: F[B])
+    extends Schema[R, F, A \/ B] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A \/ B] = :+:(nt(left), nt(right))
+  override def toString: String                    = s"$left :+: $right"
+}
+
+/**
+ * The product of two schemas, yielding the schema for `(A, B)`
+ */
+final case class :*:[F[_], A, B, R <: Realisation](left: F[A], right: F[B])
+    extends Schema[R, F, (A, B)] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, (A, B)] = :*:(nt(left), nt(right))
+  override def toString: String                    = s"$left :*: $right"
+}
+
+// "Extra" nodes, making it more convenient to represent real-world types
+
+/**
+ * The schema of a primitive type in the context of this `SchemaModule`
+ */
+final case class PrimSchema[F[_], A, R <: Realisation](prim: R#Prim[A]) extends Schema[R, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = PrimSchema[G, A, R](prim)
+}
+
+/**
+ * A named branch of an union
+ */
+final case class SumTerm[F[_], A, R <: Realisation](id: R#SumTermId, schema: F[A])
+    extends Schema[R, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = SumTerm(id, nt(schema))
+}
+
+/**
+ * An union, eg. a sum of named branches
+ */
+final case class Union[R <: Realisation, F[_], A, AE] private (choices: F[AE], iso: Iso[AE, A])
+    extends Schema[R, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = Union(nt(choices), iso)
+}
+
+/**
+ * A named field of a record
+ */
+final case class ProductTerm[F[_], A, R <: Realisation](id: R#ProductTermId, schema: F[A])
+    extends Schema[R, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = ProductTerm(id, nt(schema))
+}
+
+/**
+ * A record, eg. a product of named fields
+ */
+final case class RecordSchema[R <: Realisation, F[_], A, AP] private (
+  fields: F[AP],
+  iso: Iso[AP, A]
+) extends Schema[R, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = RecordSchema(nt(fields), iso)
+}
+
+/**
+ * A sequence
+ */
+final case class SeqSchema[F[_], A, R <: Realisation](element: F[A]) extends Schema[R, F, List[A]] {
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, List[A]] = SeqSchema(nt(element))
+}
+
+/**
+ * The schema obtained by "mapping" an Iso of top of a schema. If there is an isomorphism
+ * between AO and A, then a schema of A0 can be used to represent values of A.
+ */
+final case class IsoSchema[R <: Realisation, F[_], A0, A](base: F[A0], iso: Iso[A0, A])
+    extends Schema[R, F, A] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = IsoSchema(nt(base), iso)
+}
+
+object Schema {
+
+  // Writing final here triggers a warning, using sealed instead achieves almost the same effect
+  // without warning. See https://issues.scala-lang.org/browse/SI-4440
+
+  type FSchema[R <: Realisation, A] = Fix[Schema[R, ?[_], ?], A]
+
+  // Schema syntax
+
+  implicit final class SchemaSyntax[A, R <: Realisation](schema: FSchema[R, A]) {
+    def :*: [B](left: FSchema[R, B]): FSchema[R, (B, A)]                  = Fix(new :*:(left, schema))
+    def :+: [B](left: FSchema[R, B]): FSchema[R, B \/ A]                  = Fix(new :+:(left, schema))
+    def -*>: (id: R#ProductTermId): FSchema[R, A]                         = Fix(ProductTerm(id, schema))
+    def -+>: (id: R#SumTermId): FSchema[R, A]                             = Fix(SumTerm(id, schema))
+    def to[F[_]](implicit algebra: HAlgebra[Schema[R, ?[_], ?], F]): F[A] = cataNT(algebra)(schema)
+
+    def imap[B](_iso: Iso[A, B]): FSchema[R, B] = schema.unFix match {
+      case IsoSchema(base, iso) => Fix(IsoSchema(base, iso.composeIso(_iso)))
+      case _                    => Fix(IsoSchema(schema, _iso))
+    }
+
   }
 
-  object Schema {
+  /////////////////////////
+  // Utility typeclasses
+  /////////////////////////
+  /*
+   /**
+   * Witnesses the fact that `T` is a product whose all members are `ProductTerm`s
+   */
+   trait LabelledProduct[T]
 
-    // Writing final here triggers a warning, using sealed instead achieves almost the same effect
-    // without warning. See https://issues.scala-lang.org/browse/SI-4440
+   implicit def labelledProduct[A, B, R[_] <: Schema[_]](
+   implicit @deprecated("don't warn", "") proof: LabelledProduct[R[B]]
+   ): LabelledProduct[:*:[A, ProductTerm, B, R]] =
+   new LabelledProduct[:*:[A, ProductTerm, B, R]] {}
 
-    ////////////////////
-    // The Schema ADT
-    ////////////////////
+   implicit def singleLabelledProduct[A]: LabelledProduct[ProductTerm[A]] =
+   new LabelledProduct[ProductTerm[A]] {}
 
-    // "Essential" nodes. In theory every possible type can be represented using only `One`, `:+:` and `:*:`
+   /**
+   * Witnesses the fact that `T` is a sum whose all members are `SumTerm`s
+   */
+   trait LabelledSum[T]
 
-    sealed case class One[F[_]]() extends Schema[F, Unit] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, Unit] = One()
+   implicit def labelledSum[A, B, R[X] <: Schema[X]](
+   implicit @deprecated("don't warn", "") proof: LabelledSum[R[B]]
+   ): LabelledSum[:+:[A, SumTerm, B, R]] =
+   new LabelledSum[:+:[A, SumTerm, B, R]] {}
+
+   implicit def singleLabelledSum[A]: LabelledSum[SumTerm[A]] =
+   new LabelledSum[SumTerm[A]] {}
+   */
+  ///////////////////////
+  // Schema operations
+  ///////////////////////
+
+  type HAlgebra[F[_[_], _], G[_]] = F[G, ?] ~> G
+
+  def cataNT[R <: Realisation, F[_]](alg: HAlgebra[Schema[R, ?[_], ?], F]): (FSchema[R, ?] ~> F) =
+    new (FSchema[R, ?] ~> F) { self =>
+
+      def apply[A](f: FSchema[R, A]): F[A] =
+        alg.apply[A](f.unFix.hmap[F](self))
     }
 
-    /**
-     * The sum of two schemas, yielding the schema for `A \/ B`
-     */
-    sealed case class :+:[F[_], A, B](left: F[A], right: F[B]) extends Schema[F, A \/ B] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A \/ B] = :+:(nt(left), nt(right))
-      override def toString: String                 = s"$left :+: $right"
-    }
+}
 
-    /**
-     * The product of two schemas, yielding the schema for `(A, B)`
-     */
-    sealed case class :*:[F[_], A, B](left: F[A], right: F[B]) extends Schema[F, (A, B)] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, (A, B)] = :*:(nt(left), nt(right))
-      override def toString: String                 = s"$left :*: $right"
-    }
+trait SchemaModule[R <: Realisation] {
 
-    // "Extra" nodes, making it more convenient to represent real-world types
-
-    /**
-     * The schema of a primitive type in the context of this `SchemaModule`
-     */
-    sealed case class PrimSchema[F[_], A](prim: Prim[A]) extends Schema[F, A] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = PrimSchema[G, A](prim)
-    }
-
-    /**
-     * A named branch of an union
-     */
-    sealed case class SumTerm[F[_], A](id: SumTermId, schema: F[A]) extends Schema[F, A] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = SumTerm(id, nt(schema))
-    }
-
-    /**
-     * An union, eg. a sum of named branches
-     */
-    sealed case class Union[F[_], A, AE] private (choices: F[AE], iso: Iso[AE, A])
-        extends Schema[F, A] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = Union(nt(choices), iso)
-    }
-
-    /**
-     * A named field of a record
-     */
-    sealed case class ProductTerm[F[_], A](id: ProductTermId, schema: F[A]) extends Schema[F, A] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = ProductTerm(id, nt(schema))
-    }
-
-    /**
-     * A record, eg. a product of named fields
-     */
-    sealed case class RecordSchema[F[_], A, AP] private (fields: F[AP], iso: Iso[AP, A])
-        extends Schema[F, A] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = RecordSchema(nt(fields), iso)
-    }
-
-    /**
-     * A sequence
-     */
-    sealed case class SeqSchema[F[_], A](element: F[A]) extends Schema[F, List[A]] {
-      def hmap[G[_]](nt: F ~> G): Schema[G, List[A]] = SeqSchema(nt(element))
-    }
-
-    /**
-     * The schema obtained by "mapping" an Iso of top of a schema. If there is an isomorphism
-     * between AO and A, then a schema of A0 can be used to represent values of A.
-     */
-    sealed case class IsoSchema[F[_], A0, A](base: F[A0], iso: Iso[A0, A]) extends Schema[F, A] {
-
-      def hmap[G[_]](nt: F ~> G): Schema[G, A] = IsoSchema(nt(base), iso)
-    }
-
-    // Schema syntax
-
-    implicit final class SchemaSyntax[A](schema: Fix[Schema, A]) {
-      def :*: [B](left: Fix[Schema, B]): Fix[Schema, (B, A)]    = Fix(new :*:(left, schema))
-      def :+: [B](left: Fix[Schema, B]): Fix[Schema, B \/ A]    = Fix(new :+:(left, schema))
-      def -*>: (id: ProductTermId): Fix[Schema, A]              = Fix(ProductTerm(id, schema))
-      def -+>: (id: SumTermId): Fix[Schema, A]                  = Fix(SumTerm(id, schema))
-      def to[F[_]](implicit algebra: HAlgebra[Schema, F]): F[A] = cataNT(algebra)(schema)
-
-      def imap[B](_iso: Iso[A, B]): Fix[Schema, B] = schema.unFix match {
-        case IsoSchema(base, iso) => Fix(IsoSchema(base, iso.composeIso(_iso)))
-        case _                    => Fix(IsoSchema(schema, _iso))
-      }
-
-    }
-
-    /////////////////////////
-    // Utility typeclasses
-    /////////////////////////
-    /*
-    /**
-     * Witnesses the fact that `T` is a product whose all members are `ProductTerm`s
-     */
-    trait LabelledProduct[T]
-
-    implicit def labelledProduct[A, B, R[_] <: Schema[_]](
-      implicit @deprecated("don't warn", "") proof: LabelledProduct[R[B]]
-    ): LabelledProduct[:*:[A, ProductTerm, B, R]] =
-      new LabelledProduct[:*:[A, ProductTerm, B, R]] {}
-
-    implicit def singleLabelledProduct[A]: LabelledProduct[ProductTerm[A]] =
-      new LabelledProduct[ProductTerm[A]] {}
-
-    /**
-     * Witnesses the fact that `T` is a sum whose all members are `SumTerm`s
-     */
-    trait LabelledSum[T]
-
-    implicit def labelledSum[A, B, R[X] <: Schema[X]](
-      implicit @deprecated("don't warn", "") proof: LabelledSum[R[B]]
-    ): LabelledSum[:+:[A, SumTerm, B, R]] =
-      new LabelledSum[:+:[A, SumTerm, B, R]] {}
-
-    implicit def singleLabelledSum[A]: LabelledSum[SumTerm[A]] =
-      new LabelledSum[SumTerm[A]] {}
-     */
-    ///////////////////////
-    // Schema operations
-    ///////////////////////
-
-    type HAlgebra[F[_[_], _], G[_]] = F[G, ?] ~> G
-
-    def cataNT[F[_]](alg: HAlgebra[Schema, F]): (FSchema ~> F) =
-      new (FSchema ~> F) { self =>
-
-        def apply[A](f: Fix[Schema, A]): F[A] =
-          alg.apply[A](f.unFix.hmap[F](self))
-      }
-
-    type FSchema[A] = Fix[Schema, A]
-
-  }
+  import Schema._
 
   ////////////////
   // Public API
   ////////////////
 
-  final def unit: Schema.FSchema[Unit] = Fix(Schema.One[Schema.FSchema]())
+  final def unit: FSchema[R, Unit] = Fix(One[R, FSchema[R, ?]]())
 
-  final def prim[A](prim: Prim[A]): Schema.FSchema[A] = Fix(Schema.PrimSchema(prim))
+  final def prim[A](prim: R#Prim[A]): FSchema[R, A] = Fix(PrimSchema(prim))
 
-  final def union[A, AE](choices: Schema.FSchema[AE], iso: Iso[AE, A]) /*(
-    implicit @deprecated("don't warn", "") proof: Schema.LabelledSum[R]
-  )*/: Schema.FSchema[A] = Fix(Schema.Union(choices, iso))
+  final def union[A, AE](
+    choices: FSchema[R, AE],
+    iso: Iso[AE, A]
+  ): FSchema[R, A] =
+    Fix(Union(choices, iso))
 
-  final def optional[A](aSchema: Schema.FSchema[A]): Schema.FSchema[Option[A]] =
+  final def optional[A](aSchema: FSchema[R, A]): FSchema[R, Option[A]] =
     iso(
-      Fix(new Schema.:+:[Schema.FSchema, A, Unit](aSchema, unit)),
+      Fix(new :+:[R, FSchema[R, ?], A, Unit](aSchema, unit)),
       Iso[A \/ Unit, Option[A]](_.swap.toOption)(_.fold[A \/ Unit](\/-(()))(-\/(_)))
     )
 
-  final def record[A, An](terms: Schema.FSchema[An], isoA: Iso[An, A]) /*(
-    implicit @deprecated("don't warn", "") proof: Schema.LabelledProduct[R]
-  )*/: Schema.FSchema[A] = Fix(Schema.RecordSchema(terms, isoA))
+  final def record[A, An](
+    terms: FSchema[R, An],
+    isoA: Iso[An, A]
+  ): FSchema[R, A] =
+    Fix(RecordSchema(terms, isoA))
 
-  final def seq[A](element: Schema.FSchema[A]): Schema.FSchema[List[A]] =
-    Fix[Schema, List[A]](Schema.SeqSchema(element))
+  final def seq[A](element: FSchema[R, A]): FSchema[R, List[A]] =
+    Fix(SeqSchema(element))
 
-  final def iso[A0, A](base: Schema.FSchema[A0], iso: Iso[A0, A]): Schema.FSchema[A] =
-    Fix(Schema.IsoSchema(base, iso))
+  final def iso[A0, A](base: FSchema[R, A0], iso: Iso[A0, A]): FSchema[R, A] =
+    Fix(IsoSchema(base, iso))
 
 }

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -12,9 +12,8 @@ trait Realisation {
   type ProductTermId
 }
 
-sealed trait Schema[R <: Realisation, F[_], A] { //self =>
-
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A]
+sealed trait Schema[Prim[_], SumTermId, ProductTermId, F[_], A] { //self =>
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A]
   //    def imap[B](iso: Iso[A, B]): Schema.FSchema[B] = Schema.IsoSchema(self, iso)
 }
 
@@ -24,26 +23,31 @@ sealed trait Schema[R <: Realisation, F[_], A] { //self =>
 
 // "Essential" nodes. In theory every possible type can be represented using only `One`, `:+:` and `:*:`
 
-final case class One[R <: Realisation, F[_]]() extends Schema[R, F, Unit] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, Unit] = One()
+final case class One[Prim[_], SumTermId, ProductTermId, F[_]]()
+    extends Schema[Prim, SumTermId, ProductTermId, F, Unit] {
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, Unit] = One()
 }
 
 /**
  * The sum of two schemas, yielding the schema for `A \/ B`
  */
-final case class :+:[R <: Realisation, F[_], A, B](left: F[A], right: F[B])
-    extends Schema[R, F, A \/ B] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A \/ B] = :+:(nt(left), nt(right))
-  override def toString: String                    = s"$left :+: $right"
+final case class :+:[Prim[_], SumTermId, ProductTermId, F[_], A, B](left: F[A], right: F[B])
+    extends Schema[Prim, SumTermId, ProductTermId, F, A \/ B] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A \/ B] =
+    :+:(nt(left), nt(right))
+  override def toString: String = s"$left :+: $right"
 }
 
 /**
  * The product of two schemas, yielding the schema for `(A, B)`
  */
-final case class :*:[F[_], A, B, R <: Realisation](left: F[A], right: F[B])
-    extends Schema[R, F, (A, B)] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, (A, B)] = :*:(nt(left), nt(right))
-  override def toString: String                    = s"$left :*: $right"
+final case class :*:[F[_], A, B, Prim[_], SumTermId, ProductTermId](left: F[A], right: F[B])
+    extends Schema[Prim, SumTermId, ProductTermId, F, (A, B)] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, (A, B)] =
+    :*:(nt(left), nt(right))
+  override def toString: String = s"$left :*: $right"
 }
 
 // "Extra" nodes, making it more convenient to represent real-world types
@@ -51,59 +55,76 @@ final case class :*:[F[_], A, B, R <: Realisation](left: F[A], right: F[B])
 /**
  * The schema of a primitive type in the context of this `SchemaModule`
  */
-final case class PrimSchema[F[_], A, R <: Realisation](prim: R#Prim[A]) extends Schema[R, F, A] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = PrimSchema[G, A, R](prim)
+final case class PrimSchema[F[_], A, Prim[_], SumTermId, ProductTermId](prim: Prim[A])
+    extends Schema[Prim, SumTermId, ProductTermId, F, A] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] =
+    PrimSchema[G, A, Prim, SumTermId, ProductTermId](prim)
 }
 
 /**
  * A named branch of an union
  */
-final case class SumTerm[F[_], A, R <: Realisation](id: R#SumTermId, schema: F[A])
-    extends Schema[R, F, A] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = SumTerm(id, nt(schema))
+final case class SumTerm[F[_], A, Prim[_], SumTermId, ProductTermId](id: SumTermId, schema: F[A])
+    extends Schema[Prim, SumTermId, ProductTermId, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] = SumTerm(id, nt(schema))
 }
 
 /**
  * An union, eg. a sum of named branches
  */
-final case class Union[R <: Realisation, F[_], A, AE] private (choices: F[AE], iso: Iso[AE, A])
-    extends Schema[R, F, A] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = Union(nt(choices), iso)
+final case class Union[Prim[_], SumTermId, ProductTermId, F[_], A, AE] private (
+  choices: F[AE],
+  iso: Iso[AE, A]
+) extends Schema[Prim, SumTermId, ProductTermId, F, A] {
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] = Union(nt(choices), iso)
 }
 
 /**
  * A named field of a record
  */
-final case class ProductTerm[F[_], A, R <: Realisation](id: R#ProductTermId, schema: F[A])
-    extends Schema[R, F, A] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = ProductTerm(id, nt(schema))
+final case class ProductTerm[F[_], A, Prim[_], SumTermId, ProductTermId](
+  id: ProductTermId,
+  schema: F[A]
+) extends Schema[Prim, SumTermId, ProductTermId, F, A] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] =
+    ProductTerm(id, nt(schema))
 }
 
 /**
  * A record, eg. a product of named fields
  */
-final case class RecordSchema[R <: Realisation, F[_], A, AP] private (
+final case class RecordSchema[Prim[_], SumTermId, ProductTermId, F[_], A, AP] private (
   fields: F[AP],
   iso: Iso[AP, A]
-) extends Schema[R, F, A] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = RecordSchema(nt(fields), iso)
+) extends Schema[Prim, SumTermId, ProductTermId, F, A] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] =
+    RecordSchema(nt(fields), iso)
 }
 
 /**
  * A sequence
  */
-final case class SeqSchema[F[_], A, R <: Realisation](element: F[A]) extends Schema[R, F, List[A]] {
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, List[A]] = SeqSchema(nt(element))
+final case class SeqSchema[F[_], A, Prim[_], SumTermId, ProductTermId](element: F[A])
+    extends Schema[Prim, SumTermId, ProductTermId, F, List[A]] {
+
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, List[A]] =
+    SeqSchema(nt(element))
 }
 
 /**
  * The schema obtained by "mapping" an Iso of top of a schema. If there is an isomorphism
  * between AO and A, then a schema of A0 can be used to represent values of A.
  */
-final case class IsoSchema[R <: Realisation, F[_], A0, A](base: F[A0], iso: Iso[A0, A])
-    extends Schema[R, F, A] {
+final case class IsoSchema[Prim[_], SumTermId, ProductTermId, F[_], A0, A](
+  base: F[A0],
+  iso: Iso[A0, A]
+) extends Schema[Prim, SumTermId, ProductTermId, F, A] {
 
-  def hmap[G[_]](nt: F ~> G): Schema[R, G, A] = IsoSchema(nt(base), iso)
+  def hmap[G[_]](nt: F ~> G): Schema[Prim, SumTermId, ProductTermId, G, A] =
+    IsoSchema(nt(base), iso)
 }
 
 object Schema {
@@ -111,18 +132,32 @@ object Schema {
   // Writing final here triggers a warning, using sealed instead achieves almost the same effect
   // without warning. See https://issues.scala-lang.org/browse/SI-4440
 
-  type FSchema[R <: Realisation, A] = Fix[Schema[R, ?[_], ?], A]
+  type FSchema[Prim[_], SumTermId, ProductTermId, A] =
+    Fix[Schema[Prim, SumTermId, ProductTermId, ?[_], ?], A]
 
   // Schema syntax
 
-  implicit final class SchemaSyntax[A, R <: Realisation](schema: FSchema[R, A]) {
-    def :*: [B](left: FSchema[R, B]): FSchema[R, (B, A)]                  = Fix(new :*:(left, schema))
-    def :+: [B](left: FSchema[R, B]): FSchema[R, B \/ A]                  = Fix(new :+:(left, schema))
-    def -*>: (id: R#ProductTermId): FSchema[R, A]                         = Fix(ProductTerm(id, schema))
-    def -+>: (id: R#SumTermId): FSchema[R, A]                             = Fix(SumTerm(id, schema))
-    def to[F[_]](implicit algebra: HAlgebra[Schema[R, ?[_], ?], F]): F[A] = cataNT(algebra)(schema)
+  implicit final class SchemaSyntax[A, Prim[_], SumTermId, ProductTermId](
+    schema: FSchema[Prim, SumTermId, ProductTermId, A]
+  ) {
 
-    def imap[B](_iso: Iso[A, B]): FSchema[R, B] = schema.unFix match {
+    def :*: [B](
+      left: FSchema[Prim, SumTermId, ProductTermId, B]
+    ): FSchema[Prim, SumTermId, ProductTermId, (B, A)] = Fix(new :*:(left, schema))
+
+    def :+: [B](
+      left: FSchema[Prim, SumTermId, ProductTermId, B]
+    ): FSchema[Prim, SumTermId, ProductTermId, B \/ A] = Fix(new :+:(left, schema))
+
+    def -*>: (id: ProductTermId): FSchema[Prim, SumTermId, ProductTermId, A] =
+      Fix(ProductTerm(id, schema))
+    def -+>: (id: SumTermId): FSchema[Prim, SumTermId, ProductTermId, A] = Fix(SumTerm(id, schema))
+
+    def to[F[_]](
+      implicit algebra: HAlgebra[Schema[Prim, SumTermId, ProductTermId, ?[_], ?], F]
+    ): F[A] = cataNT(algebra)(schema)
+
+    def imap[B](_iso: Iso[A, B]): FSchema[Prim, SumTermId, ProductTermId, B] = schema.unFix match {
       case IsoSchema(base, iso) => Fix(IsoSchema(base, iso.composeIso(_iso)))
       case _                    => Fix(IsoSchema(schema, _iso))
     }
@@ -165,10 +200,12 @@ object Schema {
 
   type HAlgebra[F[_[_], _], G[_]] = F[G, ?] ~> G
 
-  def cataNT[R <: Realisation, F[_]](alg: HAlgebra[Schema[R, ?[_], ?], F]): (FSchema[R, ?] ~> F) =
-    new (FSchema[R, ?] ~> F) { self =>
+  def cataNT[Prim[_], SumTermId, ProductTermId, F[_]](
+    alg: HAlgebra[Schema[Prim, SumTermId, ProductTermId, ?[_], ?], F]
+  ): (FSchema[Prim, SumTermId, ProductTermId, ?] ~> F) =
+    new (FSchema[Prim, SumTermId, ProductTermId, ?] ~> F) { self =>
 
-      def apply[A](f: FSchema[R, A]): F[A] =
+      def apply[A](f: FSchema[Prim, SumTermId, ProductTermId, A]): F[A] =
         alg.apply[A](f.unFix.hmap[F](self))
     }
 
@@ -176,38 +213,60 @@ object Schema {
 
 trait SchemaModule[R <: Realisation] {
 
+  val R: R
+
   import Schema._
 
   ////////////////
   // Public API
   ////////////////
 
-  final def unit: FSchema[R, Unit] = Fix(One[R, FSchema[R, ?]]())
+  final def unit: FSchema[R.Prim, R.SumTermId, R.ProductTermId, Unit] =
+    Fix(
+      One[R.Prim, R.SumTermId, R.ProductTermId, FSchema[R.Prim, R.SumTermId, R.ProductTermId, ?]]()
+    )
 
-  final def prim[A](prim: R#Prim[A]): FSchema[R, A] = Fix(PrimSchema(prim))
+  final def prim[A](prim: R.Prim[A]): FSchema[R.Prim, R.SumTermId, R.ProductTermId, A] =
+    Fix(PrimSchema(prim))
 
   final def union[A, AE](
-    choices: FSchema[R, AE],
+    choices: FSchema[R.Prim, R.SumTermId, R.ProductTermId, AE],
     iso: Iso[AE, A]
-  ): FSchema[R, A] =
+  ): FSchema[R.Prim, R.SumTermId, R.ProductTermId, A] =
     Fix(Union(choices, iso))
 
-  final def optional[A](aSchema: FSchema[R, A]): FSchema[R, Option[A]] =
+  final def optional[A](
+    aSchema: FSchema[R.Prim, R.SumTermId, R.ProductTermId, A]
+  ): FSchema[R.Prim, R.SumTermId, R.ProductTermId, Option[A]] =
     iso(
-      Fix(new :+:[R, FSchema[R, ?], A, Unit](aSchema, unit)),
+      Fix(
+        new :+:[
+          R.Prim,
+          R.SumTermId,
+          R.ProductTermId,
+          FSchema[R.Prim, R.SumTermId, R.ProductTermId, ?],
+          A,
+          Unit
+        ](aSchema, unit)
+      ),
       Iso[A \/ Unit, Option[A]](_.swap.toOption)(_.fold[A \/ Unit](\/-(()))(-\/(_)))
     )
 
   final def record[A, An](
-    terms: FSchema[R, An],
+    terms: FSchema[R.Prim, R.SumTermId, R.ProductTermId, An],
     isoA: Iso[An, A]
-  ): FSchema[R, A] =
+  ): FSchema[R.Prim, R.SumTermId, R.ProductTermId, A] =
     Fix(RecordSchema(terms, isoA))
 
-  final def seq[A](element: FSchema[R, A]): FSchema[R, List[A]] =
+  final def seq[A](
+    element: FSchema[R.Prim, R.SumTermId, R.ProductTermId, A]
+  ): FSchema[R.Prim, R.SumTermId, R.ProductTermId, List[A]] =
     Fix(SeqSchema(element))
 
-  final def iso[A0, A](base: FSchema[R, A0], iso: Iso[A0, A]): FSchema[R, A] =
+  final def iso[A0, A](
+    base: FSchema[R.Prim, R.SumTermId, R.ProductTermId, A0],
+    iso: Iso[A0, A]
+  ): FSchema[R.Prim, R.SumTermId, R.ProductTermId, A] =
     Fix(IsoSchema(base, iso))
 
 }

--- a/modules/core/src/main/scala/schemas.scala
+++ b/modules/core/src/main/scala/schemas.scala
@@ -21,8 +21,10 @@ object ScalaSchema {
   final case object ScalaUnit       extends ScalaPrim[Unit]
 }
 
-object JsonSchema {
-  type Prim[A] = JsonPrim[A]
+object JsonSchema extends Realisation {
+  type Prim[A]       = JsonPrim[A]
+  type ProductTermId = String
+  type SumTermId     = String
 
   sealed trait JsonPrim[A]
   final case object JsonString extends JsonPrim[String]

--- a/modules/core/src/test/scala/JsonExamples.scala
+++ b/modules/core/src/test/scala/JsonExamples.scala
@@ -7,24 +7,23 @@ import monocle._
 
 object JsonExamples {
 
+  import Json._
+  import Schema._
+
   def tests[T](harness: Harness[T]): T = {
     import harness._
     import JsonSchema.{ Prim => _, _ }
 
-    val jsonModule = new JsonModule {
-      type Prim[A]       = JsonSchema.Prim[A]
-      type ProductTermId = String
-      type SumTermId     = String
-    }
+    val module = new JsonModule[JsonSchema.type] {}
 
-    import jsonModule._
+    import module._
 
     def matchJsonStrings(a: String, b: String): Boolean =
       a.toLowerCase.replaceAll("\\s+", "") == b.toLowerCase.replaceAll("\\s+", "")
 
     section("JSON Schema Tests")(
       test("Case Class should Serialize using Schema") { () =>
-        val role: Fix[Schema, Role] = union(
+        val role: FSchema[JsonSchema.type, Role] = union(
           "user" -+>: record(
             "active" -*>: prim(JsonSchema.JsonBool),
             Iso[Boolean, User](User.apply)(_.active)
@@ -42,7 +41,7 @@ object JsonExamples {
           }
         )
 
-        val schema: Fix[Schema, Person] = record(
+        val schema: FSchema[JsonSchema.type, Person] = record(
           "name" -*>: prim(JsonSchema.JsonString) :*:
             "role" -*>: optional(
             role
@@ -50,8 +49,8 @@ object JsonExamples {
           Iso[(String, Option[Role]), Person]((Person.apply _).tupled)(p => (p.name, p.role))
         )
 
-        implicit val primToEncoderNT = new (Prim ~> Encoder) {
-          def apply[A](fa: Prim[A]): Encoder[A] = { a =>
+        implicit val primToEncoderNT = new (JsonSchema.type#Prim ~> Encoder) {
+          def apply[A](fa: JsonSchema.type#Prim[A]): Encoder[A] = { a =>
             fa match {
               case JsonNumber => a.toString
               case JsonBool   => a.toString

--- a/modules/core/src/test/scala/JsonExamples.scala
+++ b/modules/core/src/test/scala/JsonExamples.scala
@@ -14,7 +14,9 @@ object JsonExamples {
     import harness._
     import JsonSchema.{ Prim => _, _ }
 
-    val module = new JsonModule[JsonSchema.type] {}
+    val module = new JsonModule[JsonSchema.type] {
+      override val R = JsonSchema
+    }
 
     import module._
 
@@ -23,7 +25,7 @@ object JsonExamples {
 
     section("JSON Schema Tests")(
       test("Case Class should Serialize using Schema") { () =>
-        val role: FSchema[JsonSchema.type, Role] = union(
+        val role = union(
           "user" -+>: record(
             "active" -*>: prim(JsonSchema.JsonBool),
             Iso[Boolean, User](User.apply)(_.active)
@@ -41,7 +43,7 @@ object JsonExamples {
           }
         )
 
-        val schema: FSchema[JsonSchema.type, Person] = record(
+        val schema = record(
           "name" -*>: prim(JsonSchema.JsonString) :*:
             "role" -*>: optional(
             role

--- a/modules/core/src/test/scala/SchemaModuleExamples.scala
+++ b/modules/core/src/test/scala/SchemaModuleExamples.scala
@@ -10,11 +10,7 @@ object SchemaModuleExamples {
   def tests[T](harness: Harness[T]): T = {
     import harness._
 
-    val jsonModule = new JsonModule {
-      type Prim[A]       = JsonSchema.Prim[A]
-      type ProductTermId = String
-      type SumTermId     = String
-    }
+    val jsonModule = new JsonModule[JsonSchema.type] {}
 
     import jsonModule._
 
@@ -29,8 +25,8 @@ object SchemaModuleExamples {
         )
 
         adminSchema.imap(adminToListIso).imap(listToSeqIso).unFix match {
-          case Schema.IsoSchema(base, _) => assert(base == adminSchema)
-          case _                         => assert(false)
+          case IsoSchema(base, _) => assert(base == adminSchema)
+          case _                  => assert(false)
         }
       }
     )

--- a/modules/core/src/test/scala/SchemaModuleExamples.scala
+++ b/modules/core/src/test/scala/SchemaModuleExamples.scala
@@ -10,7 +10,9 @@ object SchemaModuleExamples {
   def tests[T](harness: Harness[T]): T = {
     import harness._
 
-    val jsonModule = new JsonModule[JsonSchema.type] {}
+    val jsonModule = new JsonModule[JsonSchema.type] {
+      override val R = JsonSchema
+    }
 
     import jsonModule._
 

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -6,14 +6,14 @@ package scalacheck
 
 import org.scalacheck._
 
-trait GenModule extends SchemaModule {
+trait GenModule[R <: Realisation] extends SchemaModule[R] {
 
   import Schema._
 
-  implicit final def algebra(implicit primNT: Prim ~> Gen): HAlgebra[Schema, Gen] =
-    new (Schema[Gen, ?] ~> Gen) {
+  implicit final def algebra(implicit primNT: R#Prim ~> Gen): HAlgebra[Schema[R, ?[_], ?], Gen] =
+    new (Schema[R, Gen, ?] ~> Gen) {
 
-      def apply[A](schema: Schema[Gen, A]): Gen[A] = schema match {
+      def apply[A](schema: Schema[R, Gen, A]): Gen[A] = schema match {
         case PrimSchema(prim) => primNT(prim)
         case :*:(left, right) =>
           for {

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -10,25 +10,28 @@ trait GenModule[R <: Realisation] extends SchemaModule[R] {
 
   import Schema._
 
-  implicit final def algebra(implicit primNT: R#Prim ~> Gen): HAlgebra[Schema[R, ?[_], ?], Gen] =
-    new (Schema[R, Gen, ?] ~> Gen) {
+  implicit final def algebra(
+    implicit primNT: R.Prim ~> Gen
+  ): HAlgebra[Schema[R.Prim, R.SumTermId, R.ProductTermId, ?[_], ?], Gen] =
+    new (Schema[R.Prim, R.SumTermId, R.ProductTermId, Gen, ?] ~> Gen) {
 
-      def apply[A](schema: Schema[R, Gen, A]): Gen[A] = schema match {
-        case PrimSchema(prim) => primNT(prim)
-        case :*:(left, right) =>
-          for {
-            l <- left
-            r <- right
-          } yield (l, r)
-        case :+:(left, right)          => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
-        case IsoSchema(base, iso)      => base.map(iso.get)
-        case RecordSchema(fields, iso) => fields.map(iso.get)
-        case SeqSchema(element)        => Gen.listOf(element)
-        case ProductTerm(_, base)      => base
-        case Union(choices, iso)       => choices.map(iso.get)
-        case SumTerm(_, base)          => base
-        case One()                     => Gen.const(())
-      }
+      def apply[A](schema: Schema[R.Prim, R.SumTermId, R.ProductTermId, Gen, A]): Gen[A] =
+        schema match {
+          case PrimSchema(prim) => primNT(prim)
+          case :*:(left, right) =>
+            for {
+              l <- left
+              r <- right
+            } yield (l, r)
+          case :+:(left, right)          => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
+          case IsoSchema(base, iso)      => base.map(iso.get)
+          case RecordSchema(fields, iso) => fields.map(iso.get)
+          case SeqSchema(element)        => Gen.listOf(element)
+          case ProductTerm(_, base)      => base
+          case Union(choices, iso)       => choices.map(iso.get)
+          case SumTerm(_, base)          => base
+          case One()                     => Gen.const(())
+        }
     }
 
 }

--- a/modules/scalacheck/src/test/scala/GenModuleExamples.scala
+++ b/modules/scalacheck/src/test/scala/GenModuleExamples.scala
@@ -10,14 +10,11 @@ import monocle._
 
 object GenModuleExamples {
 
-  val jsonModule = new GenModule {
-    type Prim[A]       = JsonSchema.Prim[A]
-    type ProductTermId = String
-    type SumTermId     = String
-  }
+  val jsonModule = new GenModule[JsonSchema.type] {}
 
   def tests[T](harness: Harness[T]): T = {
     import harness._
+    import Schema._
     import jsonModule._
     import org.scalacheck.Gen
     import org.scalacheck.Arbitrary._
@@ -59,7 +56,7 @@ object GenModuleExamples {
           Person.personToTupleIso
         )
 
-        implicit val primToGenNT = new (Prim ~> Gen) {
+        implicit val primToGenNT = new (JsonSchema.Prim ~> Gen) {
           override def apply[A](prim: JsonSchema.Prim[A]): Gen[A] = prim match {
             case JsonSchema.JsonString => arbitrary[String]
             case JsonSchema.JsonNumber => arbitrary[BigDecimal]

--- a/modules/scalacheck/src/test/scala/GenModuleExamples.scala
+++ b/modules/scalacheck/src/test/scala/GenModuleExamples.scala
@@ -10,7 +10,9 @@ import monocle._
 
 object GenModuleExamples {
 
-  val jsonModule = new GenModule[JsonSchema.type] {}
+  val jsonModule = new GenModule[JsonSchema.type] {
+    val R = JsonSchema
+  }
 
   def tests[T](harness: Harness[T]): T = {
     import harness._


### PR DESCRIPTION
This allows for a, more or less, acceptable workaround for the following problem.

When we implement algebras, we are tempted to write something like: 

```scala
type Encoder[A] = A => String

val algebra = new (Schema[R, Encoder, ?] ~> Encoder) {
  def apply[A](schema: Schema[R, Encoder, A]): Encoder[A] = schema match {
    case  IsoSchema(base, iso) => base.compose(iso.get)
    // ...
  }
}
```

This would compile fine, but throw a `ClassCastException` when executed, because we confused `iso.get` with `iso.reverseGet`. It compiles because the inferred type for `base` is `Encoder[Any]` (ie. `Any => String`), so scalac lets us `compose` pretty much any function with it.

This makes perfect sense since there is no information available about the "inner" type of this `IsoSchema` (the type represented by `base`) whatsoever. All that scalac knows for sure is that `iso` is of type `Iso[_, A]`.

A workaround would be to write the same pattern as : 

```scala
    case i: IsoSchema[Encoder, _, A] => i.base.compose(i.iso.get)
```

Which wouldn't compile because there, scalac would be able to figure out that the types of `base` and `iso.get` don't align.

Unfortunately, with the current module structure, such pattern would trigger a (fatal) warning, because the path of the `IsoSchema` type isn't stable (it refers to an inner class in some trait).

This PR aims to make the paths of the `Schema` GADT members stable (by putting them at top level), while keeping the ability to abstract over the `Prim`, `ProductTermId` and `SumTermId` by bundling them into an additional type parameter on `Schema`, making such pattern compile without a warning.