### PR TITLE
Make incorrect records/unions impossible to construct (fixes #28)

### DIFF
--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -33,7 +33,7 @@ trait JsonModule[R <: Realisation] extends SchemaModule[R] {
           case :+:(left, right) => (a => a.fold(left, right))
           case i: IsoSchema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, _, A] =>
             i.base.compose(i.iso.reverseGet)
-          case r: RecordSchema[R.Prim, R.SumTermId, R.ProductTermId, Encoder, A, _] =>
+          case r: Record[R.Prim, R.SumTermId, R.ProductTermId, Encoder, A, _] =>
             encloseInBraces.compose(r.fields).compose(r.iso.reverseGet)
           case SeqSchema(element)    => (a => a.map(element).mkString("[", ",", "]"))
           case ProductTerm(id, base) => makeField(fieldLabel(id)).compose(base)

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -23,14 +23,14 @@ trait GenModule[R <: Realisation] extends SchemaModule[R] {
               l <- left
               r <- right
             } yield (l, r)
-          case :+:(left, right)          => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
-          case IsoSchema(base, iso)      => base.map(iso.get)
-          case RecordSchema(fields, iso) => fields.map(iso.get)
-          case SeqSchema(element)        => Gen.listOf(element)
-          case ProductTerm(_, base)      => base
-          case Union(choices, iso)       => choices.map(iso.get)
-          case SumTerm(_, base)          => base
-          case One()                     => Gen.const(())
+          case :+:(left, right)     => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
+          case IsoSchema(base, iso) => base.map(iso.get)
+          case Record(fields, iso)  => fields.map(iso.get)
+          case SeqSchema(element)   => Gen.listOf(element)
+          case ProductTerm(_, base) => base
+          case Union(choices, iso)  => choices.map(iso.get)
+          case SumTerm(_, base)     => base
+          case One()                => Gen.const(())
         }
     }
 


### PR DESCRIPTION
This is an easy, syntactic solution for #28.

We simply define a new ADT `LabelledSum` with its own `:+:` method accepting only `LabelledSum` arguments, and make the first argument for `union` be a `LabelledSum` instead of a more general `FSchema` (and respectively we define a `LabelledProduct` ADT for building records).

Making `Union` and `Record` (notice the renaming) be `sealed abstract case class`es make sure that they can only be instantiated through the `union` and `record` method (and therefore contain only labelled sum/products), without modifying the `Schema` ADT at all.

