### PR TITLE
removed unnecessary parameter in generic derivations.

### DIFF
--- a/modules/generic/src/main/scala/ShowModule.scala
+++ b/modules/generic/src/main/scala/ShowModule.scala
@@ -51,7 +51,6 @@ trait ShowModule[R <: Realisation] extends GenericSchemaModule[R] {
       λ[Branch[Show, ?] ~> Show](
         showL => Show.shows(x => s"""${sumLabelToString(showL.id)} = (${showL.schema.shows(x)})""")
       ),
-      λ[λ[X => () => Show[X]] ~> Show](thunk => Show.shows(x => thunk().shows(x))),
-      Show.shows[Unit](_ => "()")
+      λ[λ[X => () => Show[X]] ~> Show](thunk => Show.shows(x => thunk().shows(x)))
     )
 }

--- a/modules/tests/src/main/scala/GenericGenModule.scala
+++ b/modules/tests/src/main/scala/GenericGenModule.scala
@@ -30,15 +30,14 @@ trait GenericGenModule[R <: Realisation] extends GenericSchemaModule[R] {
     covariantTargetFunctor(
       primNT,
       λ[Gen ~> λ[X => Gen[List[X]]]](x => Gen.listOf(x)),
-      λ[Field[Gen, ?] ~> Gen](gen => gen.schema),
-      λ[Branch[Gen, ?] ~> Gen](gen => gen.schema),
+      discardingFieldLabel,
+      discardingBranchLabel,
       λ[λ[X => () => Gen[X]] ~> Gen](
         thunk =>
           Gen.delay {
             thunk()
           }
-      ),
-      Gen.const(())
+      )
     )
   )
 }

--- a/modules/tests/src/main/scala/ShowExamples.scala
+++ b/modules/tests/src/main/scala/ShowExamples.scala
@@ -42,9 +42,9 @@ object ShowExamples {
           val boss = Person("Alfred", None)
 
           val testCases: List[(Person, String)] = List(
-            Person(null, None)                                          -> """(name = ("null"), role = (()))""",
-            boss                                                        -> """(name = ("Alfred"), role = (()))""",
-            Person("Alfred the Second", Some(User(true, boss)))         -> """(name = ("Alfred the Second"), role = (user = ((active = (true), boss = (( name = ("Alfred"), role = (())))))))""",
+            Person(null, None)                                          -> """(name = ("null"), role = ())""",
+            boss                                                        -> """(name = ("Alfred"), role = ())""",
+            Person("Alfred the Second", Some(User(true, boss)))         -> """(name = ("Alfred the Second"), role = (user = ((active = (true), boss = (( name = ("Alfred"), role = ()))))))""",
             Person("Alfred the Third", Some(Admin(List("sys", "dev")))) -> """(name = ("Alfred the Third"), role = (admin = (rights = (["sys","dev"]))))"""
           )
 


### PR DESCRIPTION
Cleaned up the generic derivations. Turns out they don't need to be passed a `one` because we have `pure/conquer` from `Alt/Decidable` available. However I'm not quite sure if my instances are lawful