### PR TITLE
Make things simpler by pulling isos out of RecordF and UnionF

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,4 +29,4 @@ rewrite.rules = [
   RedundantParens,
   SortModifiers
 ]
-version = "2.0.0-RC5"
+version = "2.0.0"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,4 +29,4 @@ rewrite.rules = [
   RedundantParens,
   SortModifiers
 ]
-version = "2.0.0"
+version = "2.0.0-RC5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
 - rvm use 2.4.4 --install --fuzzy
 - gem update --system
 - gem install sass
+- gem install kramdown
 - gem install jekyll -v 3.8.3
 stages:
 - name: test

--- a/microsite/src/main/tut/interpreters/scalacheck.md
+++ b/microsite/src/main/tut/interpreters/scalacheck.md
@@ -42,7 +42,7 @@ final case class Foo(name: String, connected: Boolean)
 
 import ExampleModule._
 
-val foo = record(
+val foo = caseClass(
     "name"      -*>: prim(JsonSchema.JsonString) :*:
     "connected" -*>: prim(JsonSchema.JsonBool),
     Iso[(String, Boolean), Foo]((Foo.apply _).tupled)(f => (f.name, f.connected))

--- a/microsite/src/main/tut/schemas/index.md
+++ b/microsite/src/main/tut/schemas/index.md
@@ -135,7 +135,7 @@ To build a record from a product of labelled fields, we also need to provide an 
 ```tut
 val tupleToGreeting = Iso[(String, String), Greeting]((Greeting.apply _).tupled)(g => (g.from, g.to))
 
-val greeting = record(
+val greeting = caseClass(
   "from" -*>: prim(JsonString) :*:
   "to"   -*>: prim(JsonString),
   tupleToGreeting
@@ -159,7 +159,7 @@ val sumToMessage = Iso[Greeting \/ Bye.type, Message]{
   case Bye                => \/-(Bye)
 }
 
-val message = union(
+val message = sealedTrait(
   "Greeting" -+>: greeting :+:
   "Bye"      -+>: bye,
   sumToMessage
@@ -203,9 +203,9 @@ val eitherToTree = Iso[Node \/ Leaf, Tree]({
   case l: Leaf => \/-(l)
 })
 
-lazy val tree: Schema[Tree] = union(
-  "Node" -+>: record("l" -*>: self(tree) :*: "r" -*>: self(tree), pairToNode) :+: 
-  "Leaf" -+>: record("label" -*>: prim(JsonString), stringToLeaf), 
+lazy val tree: Schema[Tree] = sealedTrait(
+  "Node" -+>: caseClass("l" -*>: self(tree) :*: "r" -*>: self(tree), pairToNode) :+: 
+  "Leaf" -+>: caseClass("label" -*>: prim(JsonString), stringToLeaf), 
   eitherToTree
 )
 ```

--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -31,12 +31,12 @@ trait JsonModule[R <: Realisation] extends SchemaModule[R] {
           case SumF(left, right)    => (a => a.fold(left, right))
           case i: IsoSchema[Encoder, _, a] =>
             i.base.compose(i.iso.reverseGet)
-          case r: Record[Encoder, _, a] =>
-            encloseInBraces.compose(r.fields).compose(r.iso.reverseGet)
+          case r: Record[Encoder, a] =>
+            encloseInBraces.compose(r.fields)
           case SeqF(element)    => (a => a.map(element).mkString("[", ",", "]"))
           case FieldF(id, base) => makeField(fieldLabel(id)).compose(base)
-          case u: Union[Encoder, _, a] =>
-            encloseInBraces.compose(u.choices).compose(u.iso.reverseGet)
+          case u: Union[Encoder, a] =>
+            encloseInBraces.compose(u.choices)
           case BranchF(id, base)         => makeField(branchLabel(id)).compose(base)
           case One()                     => (_ => "null")
           case ref @ SelfReference(_, _) => (a => ref.unroll(a))

--- a/modules/core/src/main/scala/migrations.scala
+++ b/modules/core/src/main/scala/migrations.scala
@@ -82,13 +82,15 @@ trait HasMigration[R <: Realisation] extends SchemaModule[R] {
       }
   }
 
-  implicit class MigrationRecordOps[Rn: IsRecord, An, A](rec: SchemaZ[RRecord[Rn, An, A], A]) {
+  implicit class MigrationRecordOps[Rn: IsRecord, An, A](
+    rec: SchemaZ[RIso[RRecord[Rn, An], An, A], A]
+  ) {
 
     def addField[N <: R.ProductTermId, X](name: N, default: X)(
       implicit transfo: DoAddField[N, Rn, An, X]
-    ): SchemaZ[RRecord[transfo.ROut, An, A], A] = rec.unFix match {
-      case RecordF(fields, isoA) =>
-        record[transfo.ROut, A, An](
+    ): SchemaZ[RIso[RRecord[transfo.ROut, An], An, A], A] = rec.unFix match {
+      case IsoSchemaF(recursion.Fix(RecordF(fields)), isoA) =>
+        caseClass[transfo.ROut, An, A](
           transfo(fields.asInstanceOf[SchemaZ[Rn, An]], default),
           isoA.asInstanceOf[Iso[An, A]]
         )(

--- a/modules/generic/src/main/scala/GenericAlgebra.scala
+++ b/modules/generic/src/main/scala/GenericAlgebra.scala
@@ -25,10 +25,10 @@ trait GenericSchemaModule[R <: Realisation] extends SchemaModule[R] {
           case x: Sum[H, a, b]           => H.either2(x.left, x.right)
           case x: Prod[H, a, b]          => H.tuple2(x.left, x.right)
           case x: IsoSchema[H, a0, a]    => H.map(x.base)(x.iso.get)
-          case x: Record[H, a0, a]       => H.map(x.fields)(x.iso.get)
+          case x: Record[H, a]           => x.fields
           case x: Sequence[H, a]         => seqNT(x.element)
           case pt: Field[H, a]           => prodLabelNT(pt)
-          case x: Union[H, a0, a]        => H.map(x.choices)(x.iso.get)
+          case x: Union[H, a]            => x.choices
           case st: Branch[H, a]          => sumLabelNT(st)
           case _: ROne[H]                => H.pure(())
           case ref @ SelfReference(_, _) => delay(() => ref.unroll)
@@ -55,10 +55,10 @@ trait GenericSchemaModule[R <: Realisation] extends SchemaModule[R] {
           //Luckily does not compile
           //case x: IsoSchema[_, a, a0]    => H.contramap(x.base)(x.iso.get)
           case x: IsoSchema[H, a, a0]    => H.contramap(x.base)(x.iso.reverseGet)
-          case x: Record[H, a, a0]       => H.contramap(x.fields)(x.iso.reverseGet)
+          case x: Record[H, a]           => x.fields
           case x: Sequence[H, a]         => seqNT(x.element)
           case pt: Field[H, a]           => prodLabelNT(pt)
-          case x: Union[H, a0, a]        => H.contramap(x.choices)(x.iso.reverseGet)
+          case x: Union[H, a]            => x.choices
           case st: Branch[H, a]          => sumLabelNT(st)
           case _: ROne[H]                => H.xproduct0[Unit](())
           case ref @ SelfReference(_, _) => delay(() => ref.unroll)

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -22,10 +22,10 @@ trait GenModule[R <: Realisation] extends SchemaModule[R] {
             } yield (l, r)
           case SumF(left, right)         => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
           case IsoSchemaF(base, iso)     => base.map(iso.get)
-          case RecordF(fields, iso)      => fields.map(iso.get)
+          case RecordF(fields)           => fields
           case SeqF(element)             => Gen.listOf(element)
           case FieldF(_, base)           => base
-          case UnionF(choices, iso)      => choices.map(iso.get)
+          case UnionF(choices)           => choices
           case BranchF(_, base)          => base
           case One()                     => Gen.const(())
           case ref @ SelfReference(_, _) => Gen.delay(ref.unroll)

--- a/modules/tests/src/main/scala/MigrationExamples.scala
+++ b/modules/tests/src/main/scala/MigrationExamples.scala
@@ -53,7 +53,7 @@ object MigrationExamples {
 
     val person = version0.lookup[Person]
 
-    val personV0 = record(
+    val personV0 = caseClass(
       "role" -*>: optional(current.lookup[Role]),
       Iso[Option[Role], PersonV0](PersonV0.apply)(p => p.role)
     )

--- a/modules/tests/src/main/scala/Person.scala
+++ b/modules/tests/src/main/scala/Person.scala
@@ -26,20 +26,20 @@ trait TestModule extends SchemaModule[JsonSchema.type] with Versioning[JsonSchem
 
   val current = Current
     .schema(
-      record(
+      caseClass(
         "active".narrow -*>: prim(JsonSchema.JsonBool),
         Iso[Boolean, User](User.apply)(u => u.active)
       )
     )
     .schema(
-      record(
+      caseClass(
         "rights".narrow -*>: seq(prim(JsonSchema.JsonString)),
         Iso[List[String], Admin](Admin.apply)(_.rights)
       )
     )
     .schema(
       (u: Schema[User], a: Schema[Admin]) =>
-        union(
+        sealedTrait(
           "user".narrow -+>: u :+:
             "admin".narrow -+>: a,
           Iso[User \/ Admin, Role] {
@@ -53,7 +53,7 @@ trait TestModule extends SchemaModule[JsonSchema.type] with Versioning[JsonSchem
     )
     .schema(
       (r: Schema[Role]) =>
-        record(
+        caseClass(
           "name".narrow -*>: prim(JsonSchema.JsonString) :*:
             "role".narrow -*>: optional(
             r

--- a/modules/tests/src/main/scala/SchemaModuleExamples.scala
+++ b/modules/tests/src/main/scala/SchemaModuleExamples.scala
@@ -21,13 +21,15 @@ object SchemaModuleExamples {
         val adminToListIso  = Iso[Admin, List[String]](_.rights)(Admin.apply)
         def listToSeqIso[A] = Iso[List[A], Seq[A]](_.toSeq)(_.toList)
 
-        val adminSchema = record(
-          "rights" -*>: seq(prim(JsonSchema.JsonString)),
+        val adminRecord = "rights" -*>: seq(prim(JsonSchema.JsonString))
+
+        val adminSchema = caseClass(
+          adminRecord,
           Iso[List[String], Admin](Admin.apply)(_.rights)
         )
 
         adminSchema.imap(adminToListIso).imap(listToSeqIso).unFix match {
-          case IsoSchemaF(base, _) => assert(base == adminSchema)
+          case IsoSchemaF(base, _) => assert(base == record(adminRecord))
           case _                   => assert(false)
         }
       }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.0")
+addSbtPlugin("org.spartanz"  % "sbt-org-policies" % "0.1.1")
 addSbtPlugin("com.47deg"     % "sbt-microsites"   % "0.7.27")
 addSbtPlugin("org.scoverage" % "sbt-scoverage"    % "1.5.1")


### PR DESCRIPTION
This makes `RecordF` and `UnionF` simple wrappers around products (resp. records) by removing the `iso` fields from them.

Beside simplifying some derivation implementations, it might open the way to schema serialization!