### PR TITLE
Strip out isos

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,4 +29,4 @@ rewrite.rules = [
   RedundantParens,
   SortModifiers
 ]
-version = "2.0.0-RC5"
+version = "2.0.0"

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,4 +29,4 @@ rewrite.rules = [
   RedundantParens,
   SortModifiers
 ]
-version = "2.0.0"
+version = "2.0.0-RC5"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %% "monocle-core"  % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion
-    ).map(_.exclude("org.scalaz", "scalaz")) 
+    ).map(_.exclude("org.scalaz", "scalaz"))
   )
 
 lazy val generic = project

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,7 @@ lazy val core = project
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %% "monocle-core"  % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion
-    ).map(_.exclude("org.scalaz", "scalaz")) //,
-//    addCompilerPlugin("io.tryp" % "splain" % "0.4.1" cross CrossVersion.patch)
+    ).map(_.exclude("org.scalaz", "scalaz")) 
   )
 
 lazy val generic = project

--- a/microsite/src/main/tut/interpreters/scalacheck.md
+++ b/microsite/src/main/tut/interpreters/scalacheck.md
@@ -45,7 +45,7 @@ import ExampleModule._
 val foo = caseClass(
     "name"      -*>: prim(JsonSchema.JsonString) :*:
     "connected" -*>: prim(JsonSchema.JsonBool),
-    Iso[(String, Boolean), Foo]((Foo.apply _).tupled)(f => (f.name, f.connected))
+    NIso[(String, Boolean), Foo]((Foo.apply _).tupled, f => (f.name, f.connected))
   )
   
 ```

--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -29,8 +29,6 @@ trait JsonModule[R <: Realisation] extends SchemaModule[R] {
           case p: RPrim[Encoder, a] => primNT(p.prim)
           case ProdF(left, right)   => (a => left(a._1) + "," + right(a._2))
           case SumF(left, right)    => (a => a.fold(left, right))
-          case i: IsoSchema[Encoder, _, a] =>
-            i.base.compose(i.iso.reverseGet)
           case r: Record[Encoder, a] =>
             encloseInBraces.compose(r.fields)
           case SeqF(element)    => (a => a.map(element).mkString("[", ",", "]"))

--- a/modules/core/src/main/scala/Json.scala
+++ b/modules/core/src/main/scala/Json.scala
@@ -13,6 +13,10 @@ object Json {
 trait JsonModule[R <: Realisation] extends SchemaModule[R] {
   import Json._
 
+  implicit object EncoderTransform extends Transform[Encoder] {
+    def apply[A, B](fa: Encoder[A], p: NIso[A, B]): Encoder[B] = fa.compose(p.g)
+  }
+
   implicit final def encoderInterpreter(
     implicit primNT: R.Prim ~> Encoder,
     fieldLabel: R.ProductTermId <~< String,

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -13,7 +13,6 @@ trait Realisation {
 object Representation {
   type RSum[RA, A, RB, B]
   type RProd[RA, A, RB, B]
-  //type RIso[RA, A, B]
   type RSelf[A]
   type RSeq[R, A]
   type -*>[K, V]
@@ -336,7 +335,6 @@ trait SchemaModule[R <: Realisation] {
     def to[F[_]](implicit interpreter: RInterpreter[F], trans: Transform[F]): F[T] =
       trans(interpreter.interpret(schema), p)
 
-//    def imap[B](niso: NIso[T, B]): SchemaZ.Aux[Repr, ]
   }
 
   object SchemaZ {

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -2,8 +2,6 @@ package schemaz
 import scala.annotation.implicitNotFound
 
 import recursion._
-
-import monocle.Iso
 import scalaz.{ -\/, \/, \/-, ~> }
 
 trait Realisation {
@@ -15,13 +13,41 @@ trait Realisation {
 object Representation {
   type RSum[RA, A, RB, B]
   type RProd[RA, A, RB, B]
-  type RIso[RA, A, B]
+  //type RIso[RA, A, B]
   type RSelf[A]
   type RSeq[R, A]
   type -*>[K, V]
   type -+>[K, V]
   type RRecord[RA, A]
   type RUnion[RA, A]
+}
+
+trait Distributes[P[_, _], Q[_, _]] {
+  def dist[A0, A1, B0, B1](pa: P[A0, A1], pb: P[B0, B1]): P[Q[A0, B0], Q[A1, B1]]
+}
+
+final case class NIso[A, B](f: A => B, g: B => A) {
+
+  def compose[C](other: NIso[B, C]): NIso[A, C] = NIso(other.f.compose(f), g.compose(other.g))
+}
+
+object NIso {
+
+  def id[A] = NIso[A, A](identity, identity)
+
+  implicit val nisoDistributesOverProduct: Distributes[NIso, Tuple2] =
+    new Distributes[NIso, Tuple2] {
+
+      def dist[A0, A1, B0, B1](pa: NIso[A0, A1], pb: NIso[B0, B1]): NIso[(A0, B0), (A1, B1)] =
+        NIso(p0 => (pa.f(p0._1), pb.f(p0._2)), p1 => (pa.g(p1._1), pb.g(p1._2)))
+    }
+
+  implicit val nisoDistributesOverSum: Distributes[NIso, \/] = new Distributes[NIso, \/] {
+
+    def dist[A0, A1, B0, B1](pa: NIso[A0, A1], pb: NIso[B0, B1]): NIso[A0 \/ B0, A1 \/ B1] =
+      NIso(e0 => e0.bimap(pa.f, pb.f), e1 => e1.bimap(pa.g, pb.g))
+  }
+
 }
 
 import Representation._
@@ -146,19 +172,6 @@ final case class SeqF[F[_], A, Prim[_], SumTermId, ProductTermId](element: F[A])
     SeqF(nt(element))
 }
 
-/**
- * The schema obtained by "mapping" an Iso of top of a schema. If there is an isomorphism
- * between AO and A, then a schema of A0 can be used to represent values of A.
- */
-final case class IsoSchemaF[F[_], A0, A, Prim[_], SumTermId, ProductTermId](
-  base: F[A0],
-  iso: Iso[A0, A]
-) extends SchemaF[Prim, SumTermId, ProductTermId, F, A] {
-
-  def hmap[G[_]](nt: F ~> G): SchemaF[Prim, SumTermId, ProductTermId, G, A] =
-    IsoSchemaF(nt(base), iso)
-}
-
 final case class SelfReference[F[_], H[_], A, Prim[_], SumTermId, ProductTermId](
   private val ref: () => F[A],
   private val nattrans: F ~> H
@@ -222,8 +235,9 @@ object IsRecord {
   implicit def productIsRecord[L: IsRecord, R: IsRecord, X, Y]: IsRecord[RProd[L, X, R, Y]] =
     new IsRecord[RProd[L, X, R, Y]] {}
 
-  implicit def isoIsRecord[R: IsRecord, A0, A]: IsRecord[RIso[R, A0, A]] =
+  /* implicit def isoIsRecord[R: IsRecord, A0, A]: IsRecord[RIso[R, A0, A]] =
     new IsRecord[RIso[R, A0, A]] {}
+ */
 }
 
 @implicitNotFound(
@@ -235,7 +249,7 @@ object IsUnion {
 
   implicit def singleBranchIsUnion[K, V]: IsUnion[K -+> V] = new IsUnion[K -+> V] {}
 
-  implicit def productIsUnion[L: IsUnion, R: IsUnion, X, Y]: IsUnion[RSum[L, X, R, Y]] =
+  implicit def sumIsUnion[L: IsUnion, R: IsUnion, X, Y]: IsUnion[RSum[L, X, R, Y]] =
     new IsUnion[RSum[L, X, R, Y]] {}
 }
 
@@ -259,6 +273,13 @@ object SchemaF {
 }
 
 trait Tagged[Repr]
+final class Tag[Repr] {
+  def apply[A](a: A): A with Tagged[Repr] = a.asInstanceOf
+}
+
+object Tag {
+  def apply[Repr] = new Tag[Repr]
+}
 
 trait SchemaModule[R <: Realisation] {
 
@@ -271,23 +292,56 @@ trait SchemaModule[R <: Realisation] {
   type Schema[A] =
     Fix[SchemaF[R.Prim, R.SumTermId, R.ProductTermId, ?[_], ?], A]
 
-  type SchemaZ[Repr, A] = Schema[A] with Tagged[Repr]
+  sealed case class SchemaZ[P[_, _], Repr, A, T](p: P[A, T], schema: Schema[A] with Tagged[Repr]) {
 
-  object SchemaZ {
-    def apply[Repr, A](schema: Schema[A]): SchemaZ[Repr, A] = schema.asInstanceOf[SchemaZ[Repr, A]]
+    def :*: [R2, B, U](
+      left: SchemaZ[P, R2, B, U]
+    )(implicit P: Distributes[P, Tuple2]): SchemaZ[P, RProd[R2, B, Repr, A], (B, A), (U, T)] =
+      SchemaZ(
+        P.dist(left.p, p),
+        Tag[RProd[R2, B, Repr, A]].apply[Schema[(B, A)]](Fix(new ProdF(left.schema, schema)))
+      )
+
+    def :+: [R2, B, U](
+      left: SchemaZ[P, R2, B, U]
+    )(implicit P: Distributes[P, \/]): SchemaZ[P, RSum[R2, B, Repr, A], B \/ A, U \/ T] =
+      SchemaZ(
+        P.dist(left.p, p),
+        Tag[RSum[R2, B, Repr, A]].apply[Schema[B \/ A]](Fix(new SumF(left.schema, schema)))
+      )
+
+    def -*>: [I <: R.ProductTermId](
+      id: I
+    ): SchemaZ[P, I -*> Repr, A, T] =
+      SchemaZ(
+        p,
+        Tag[I -*> Repr].apply[Schema[A]](Fix(FieldF(id.asInstanceOf[R.ProductTermId], schema)))
+      )
+
+    def -+>: [I <: R.SumTermId](id: I): SchemaZ[P, I -+> Repr, A, T] =
+      SchemaZ(
+        p,
+        Tag[I -+> Repr].apply[Schema[A]](Fix(BranchF(id.asInstanceOf[R.SumTermId], schema)))
+      )
+
+    def to[F[_]](implicit interpreter: RInterpreter[F]): F[A] = interpreter.interpret(schema)
+
   }
 
-  type ROne[F[_]]            = One[F, R.Prim, R.SumTermId, R.ProductTermId]
-  type RPrim[F[_], A]        = PrimSchemaF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type Sum[F[_], A, B]       = SumF[F, A, B, R.Prim, R.SumTermId, R.ProductTermId]
-  type Prod[F[_], A, B]      = ProdF[F, A, B, R.Prim, R.SumTermId, R.ProductTermId]
-  type Branch[F[_], A]       = BranchF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type Union[F[_], A]        = UnionF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type Field[F[_], A]        = FieldF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type Record[F[_], A]       = RecordF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type Sequence[F[_], A]     = SeqF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
-  type IsoSchema[F[_], A, B] = IsoSchemaF[F, A, B, R.Prim, R.SumTermId, R.ProductTermId]
-  type Self[F[_], A]         = SelfReference[Any, F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  object SchemaZ {
+//    def apply[Repr, A](schema: Schema[A]): SchemaZ[Repr, A] = schema.asInstanceOf[SchemaZ[Repr, A]]
+  }
+
+  type ROne[F[_]]        = One[F, R.Prim, R.SumTermId, R.ProductTermId]
+  type RPrim[F[_], A]    = PrimSchemaF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Sum[F[_], A, B]   = SumF[F, A, B, R.Prim, R.SumTermId, R.ProductTermId]
+  type Prod[F[_], A, B]  = ProdF[F, A, B, R.Prim, R.SumTermId, R.ProductTermId]
+  type Branch[F[_], A]   = BranchF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Union[F[_], A]    = UnionF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Field[F[_], A]    = FieldF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Record[F[_], A]   = RecordF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Sequence[F[_], A] = SeqF[F, A, R.Prim, R.SumTermId, R.ProductTermId]
+  type Self[F[_], A]     = SelfReference[Any, F, A, R.Prim, R.SumTermId, R.ProductTermId]
 
   object Interpreter {
 
@@ -299,110 +353,87 @@ trait SchemaModule[R <: Realisation] {
     ) = new HyloInterpreter(coalg, alg)
 
   }
+
   ////////////////
   // Public API
   ////////////////
 
-  implicit final class SchemaSyntax[A](schema: Schema[A]) {
-
-    def -*>: [I <: R.ProductTermId](
-      id: I
-    ): SchemaZ[I -*> A, A] =
-      SchemaZ(Fix(FieldF(id.asInstanceOf[R.ProductTermId], schema)))
-
-    def -+>: [I <: R.SumTermId](id: I): SchemaZ[I -+> A, A] =
-      SchemaZ(Fix(BranchF(id.asInstanceOf[R.SumTermId], schema)))
-
-    def to[F[_]](implicit interpreter: RInterpreter[F]): F[A] = interpreter.interpret(schema)
-
-  }
-
-  implicit final class SchemaZSyntax[Repr, A](schema: SchemaZ[Repr, A]) {
-
-    def :*: [R2, B](left: SchemaZ[R2, B]): SchemaZ[RProd[R2, B, Repr, A], (B, A)] =
-      SchemaZ(Fix(new ProdF(left, schema)))
-
-    def :+: [R2, B](left: SchemaZ[R2, B]): SchemaZ[RSum[R2, B, Repr, A], B \/ A] =
-      SchemaZ(Fix(new SumF(left, schema)))
-
-    def -*>: [I <: R.ProductTermId](
-      id: I
-    ): SchemaZ[I -*> Repr, A] =
-      SchemaZ(Fix(FieldF(id.asInstanceOf[R.ProductTermId], schema)))
-
-    def -+>: [I <: R.SumTermId](id: I): SchemaZ[I -+> Repr, A] =
-      SchemaZ(Fix(BranchF(id.asInstanceOf[R.SumTermId], schema)))
-
-    def to[F[_]](implicit interpreter: RInterpreter[F]): F[A] = interpreter.interpret(schema)
-
-    def imap[B](_iso: Iso[A, B]): SchemaZ[RIso[Repr, A, B], B] = schema.unFix match {
-      case IsoSchemaF(base, i) => SchemaZ(Fix(IsoSchemaF(base, i.composeIso(_iso))))
-      case x                   => SchemaZ(Fix(IsoSchemaF(Fix(x), _iso)))
-    }
-
-  }
-
-  final def unit: SchemaZ[Unit, Unit] =
+  final def unit: SchemaZ[NIso, Unit, Unit, Unit] =
     SchemaZ(
-      Fix(
-        One()
+      NIso.id,
+      Tag[Unit].apply[Schema[Unit]](
+        Fix(
+          One()
+        )
       )
     )
 
-  final def prim[A](prim: R.Prim[A]): SchemaZ[A, A] =
+  final def prim[A](prim: R.Prim[A]): SchemaZ[NIso, A, A, A] =
     SchemaZ(
-      Fix(
-        PrimSchemaF(prim)
+      NIso.id,
+      Tag[A].apply[Schema[A]](
+        Fix(
+          PrimSchemaF(prim)
+        )
       )
     )
 
-  final def union[Repr: IsUnion, A](
-    choices: SchemaZ[Repr, A]
-  ): SchemaZ[RUnion[Repr, A], A] =
-    SchemaZ(Fix(UnionF(choices)))
+  final def union[Repr: IsUnion, A, T](
+    choices: SchemaZ[NIso, Repr, A, T]
+  ): SchemaZ[NIso, RUnion[Repr, A], A, T] =
+    SchemaZ(choices.p, Tag[RUnion[Repr, A]].apply[Schema[A]](Fix(UnionF(choices.schema))))
 
-  final def sealedTrait[Repr: IsUnion, Branches, A](
-    branches: SchemaZ[Repr, Branches],
-    isoA: Iso[Branches, A]
-  ): SchemaZ[RIso[RUnion[Repr, Branches], Branches, A], A] =
-    iso(union(branches), isoA)
+  final def sealedTrait[Repr: IsUnion, Branches, A, T](
+    branches: SchemaZ[NIso, Repr, A, Branches],
+    isoA: NIso[Branches, T]
+  ): SchemaZ[NIso, RUnion[Repr, Branches], A, T] =
+    SchemaZ(
+      branches.p.compose(isoA),
+      Tag[RUnion[Repr, Branches]].apply[Schema[A]](union(branches).schema)
+    )
 
   final def optional[A](
     aSchema: Schema[A]
-  ): SchemaZ[RIso[RSum[A, A, Unit, Unit], A \/ Unit, Option[A]], Option[A]] =
-    iso(
-      SchemaZ[RSum[A, A, Unit, Unit], A \/ Unit](
-        Fix(SumF(aSchema, unit))
-      ),
-      Iso[A \/ Unit, Option[A]](_.swap.toOption)(_.fold[A \/ Unit](\/-(()))(-\/(_)))
+  ): SchemaZ[NIso, RSum[A, A, Unit, Unit], A \/ Unit, Option[A]] =
+    SchemaZ(
+      NIso[A \/ Unit, Option[A]](_.swap.toOption, _.fold[A \/ Unit](\/-(()))(-\/(_))),
+      Tag[RSum[A, A, Unit, Unit]].apply[Schema[A \/ Unit]](Fix(SumF(aSchema, unit.schema)))
     )
 
-  final def record[Repr: IsRecord, A](
-    terms: SchemaZ[Repr, A]
-  ): SchemaZ[RRecord[Repr, A], A] =
-    SchemaZ(Fix(RecordF(terms)))
+  final def record[Repr: IsRecord, A0, A](
+    terms: SchemaZ[NIso, Repr, A0, A]
+  ): SchemaZ[NIso, RRecord[Repr, A], A0, A] =
+    SchemaZ(terms.p, Tag[RRecord[Repr, A]].apply[Schema[A0]](Fix(RecordF(terms.schema))))
 
-  final def caseClass[Repr: IsRecord, Fields, A](
-    fields: SchemaZ[Repr, Fields],
-    isoA: Iso[Fields, A]
-  ): SchemaZ[RIso[RRecord[Repr, Fields], Fields, A], A] =
-    iso(record(fields), isoA)
+  final def caseClass[Repr: IsRecord, Fields, A, T](
+    fields: SchemaZ[NIso, Repr, A, Fields],
+    isoA: NIso[Fields, T]
+  ): SchemaZ[NIso, RRecord[Repr, Fields], A, T] =
+    SchemaZ(fields.p.compose(isoA), record(fields).schema)
 
-  final def seq[Repr, A](element: SchemaZ[Repr, A]): SchemaZ[RSeq[Repr, A], List[A]] =
-    SchemaZ(Fix(SeqF(element)))
-
-  final def iso[Repr, A0, A](
-    base: SchemaZ[Repr, A0],
-    iso: Iso[A0, A]
-  ): SchemaZ[RIso[Repr, A0, A], A] =
-    SchemaZ(Fix(IsoSchemaF(base, iso)))
-
-  final def self[A](root: => Schema[A]): SchemaZ[RSelf[A], A] =
+  final def seq[Repr, A, T](
+    element: SchemaZ[NIso, Repr, A, T]
+  ): SchemaZ[NIso, RSeq[Repr, A], List[A], List[T]] =
     SchemaZ(
-      Fix(
-        SelfReference(() => root, new (Schema ~> Schema) {
-          def apply[X](a: Schema[X]) = a
-        })
+      NIso[List[A], List[T]](_.map(element.p.f), _.map(element.p.g)),
+      Tag[RSeq[Repr, A]].apply[Schema[List[A]]](Fix(SeqF(element.schema)))
+    )
+
+  final def iso[Repr, A00, A0, A](
+    base: SchemaZ[NIso, Repr, A00, A0],
+    iso: NIso[A0, A]
+  ): SchemaZ[NIso, Repr, A00, A] =
+    SchemaZ(base.p.compose(iso), base.schema)
+
+  final def self[A](root: => Schema[A]): SchemaZ[NIso, RSelf[A], A, A] =
+    SchemaZ(
+      NIso.id,
+      Tag[RSelf[A]].apply[Schema[A]](
+        Fix(
+          SelfReference(() => root, new (Schema ~> Schema) {
+            def apply[X](a: Schema[X]) = a
+          })
+        )
       )
     )
 

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -278,7 +278,7 @@ object SchemaF {
 
 trait Tagged[Repr]
 final class Tag[Repr] {
-  def apply[A](a: A): A with Tagged[Repr] = a.asInstanceOf
+  def apply[A](a: A): A with Tagged[Repr] = a.asInstanceOf[A with Tagged[Repr]]
 }
 
 object Tag {
@@ -335,6 +335,8 @@ trait SchemaModule[R <: Realisation] {
 
     def to[F[_]](implicit interpreter: RInterpreter[F], trans: Transform[F]): F[T] =
       trans(interpreter.interpret(schema), p)
+
+//    def imap[B](niso: NIso[T, B]): SchemaZ.Aux[Repr, ]
   }
 
   object SchemaZ {

--- a/modules/core/src/main/scala/SchemaModule.scala
+++ b/modules/core/src/main/scala/SchemaModule.scala
@@ -1,4 +1,4 @@
-package schemaz
+\package schemaz
 import scala.annotation.implicitNotFound
 
 import recursion._

--- a/modules/core/src/main/scala/Versioning.scala
+++ b/modules/core/src/main/scala/Versioning.scala
@@ -1,7 +1,7 @@
 package schemaz
 
 trait Versioning[R <: Realisation] extends SchemaModule[R] {
-  /*
+
   final val Current: Version[Unit, Unit] = new Version(())
 
   sealed case class Version[Types, Re](registry: Re)(
@@ -277,5 +277,5 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
     }
 
   }
- */
+
 }

--- a/modules/core/src/main/scala/Versioning.scala
+++ b/modules/core/src/main/scala/Versioning.scala
@@ -12,28 +12,28 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
 
     def schema[A, RA, T](leaf: SchemaZ.Aux[RA, A, T])(
       implicit add: Version.AddEntry[Types, Unit, A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry((_: Unit) => leaf)), registry)
       )
 
     def schema[A, RA, D, T](ctr: D => SchemaZ.Aux[RA, A, T])(
       implicit add: Version.AddEntry[Types, D, A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr)), registry)
       )
 
     def schema[A, RA, D1, D2, T](ctr: (D1, D2) => SchemaZ.Aux[RA, A, T])(
       implicit add: Version.AddEntry[Types, (D1, D2), A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
 
     def schema[A, RA, D1, D2, D3, T](ctr: (D1, D2, D3) => SchemaZ.Aux[RA, A, T])(
       implicit add: Version.AddEntry[Types, (D1, D2, D3), A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
@@ -42,7 +42,7 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
       ctr: (D1, D2, D3, D4) => SchemaZ.Aux[RA, A, T]
     )(
       implicit add: Version.AddEntry[Types, (D1, D2, D3, D4), A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
@@ -51,7 +51,7 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
       ctr: (D1, D2, D3, D4, D5) => SchemaZ.Aux[RA, A, T]
     )(
       implicit add: Version.AddEntry[Types, (D1, D2, D3, D4, D5), A, RA, T]
-    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+    ): Version[(SchemaZ[T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
@@ -76,6 +76,13 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
     ): Version[Types, Re1] = {
       val migrated = lookup(registry).post(migration)
       new Version[Types, Re1](replace(registry, migrated))
+    }
+
+    def replace[RA1, A1, Re1](migration: SchemaZ.Aux[RA, A, T] => SchemaZ.Aux[RA1, A1, T])(
+      implicit replace: Version.Replace.Aux[Re, A, RA, A1, RA1, D, T, Re1]
+    ) = {
+      assert(migration != null)
+      replace
     }
   }
 
@@ -282,12 +289,12 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
 
       implicit def buildVersion[A, T, Tpe, Reg, RA](
         implicit rest: Build[Tpe, Reg]
-      ): Build[(SchemaZ.Aux[RA, A, T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] =
-        new Build[(SchemaZ.Aux[RA, A, T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] {
+      ): Build[(SchemaZ[T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] =
+        new Build[(SchemaZ[T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] {
 
           def apply(
             ctrReg: (Version.Entry.Aux[A, T, RA, Tpe], Reg)
-          ): (SchemaZ.Aux[RA, A, T], Tpe) = {
+          ): (SchemaZ[T], Tpe) = {
             val tail = rest(ctrReg._2)
 
             (ctrReg._1.entry(tail), tail)

--- a/modules/core/src/main/scala/Versioning.scala
+++ b/modules/core/src/main/scala/Versioning.scala
@@ -10,225 +10,262 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
 
     lazy val types: Types = build(registry)
 
-    def schema[P[_, _], A, RA, T](leaf: SchemaZ[P, RA, A, T])(
-      implicit add: Version.AddEntry[Types, Unit, A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
-      new Version((add(Version.Entry((_: Unit) => leaf)), registry))
+    def schema[A, RA, T](leaf: SchemaZ.Aux[RA, A, T])(
+      implicit add: Version.AddEntry[Types, Unit, A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+      new Version(
+        (add(Version.Entry((_: Unit) => leaf)), registry)
+      )
 
-    def schema[P[_, _], A, RA, D, T](ctr: D => SchemaZ[P, RA, A, T])(
-      implicit add: Version.AddEntry[Types, D, A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
+    def schema[A, RA, D, T](ctr: D => SchemaZ.Aux[RA, A, T])(
+      implicit add: Version.AddEntry[Types, D, A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr)), registry)
       )
 
-    def schema[P[_, _], A, RA, D1, D2, T](ctr: (D1, D2) => SchemaZ[P, RA, A, T])(
-      implicit add: Version.AddEntry[Types, (D1, D2), A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
+    def schema[A, RA, D1, D2, T](ctr: (D1, D2) => SchemaZ.Aux[RA, A, T])(
+      implicit add: Version.AddEntry[Types, (D1, D2), A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
 
-    def schema[P[_, _], A, RA, D1, D2, D3, T](ctr: (D1, D2, D3) => SchemaZ[P, RA, A, T])(
-      implicit add: Version.AddEntry[Types, (D1, D2, D3), A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
+    def schema[A, RA, D1, D2, D3, T](ctr: (D1, D2, D3) => SchemaZ.Aux[RA, A, T])(
+      implicit add: Version.AddEntry[Types, (D1, D2, D3), A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
 
-    def schema[P[_, _], A, RA, D1, D2, D3, D4, T](ctr: (D1, D2, D3, D4) => SchemaZ[P, RA, A, T])(
-      implicit add: Version.AddEntry[Types, (D1, D2, D3, D4), A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
-      new Version(
-        (add(Version.Entry(ctr.tupled)), registry)
-      )
-
-    def schema[P[_, _], A, RA, D1, D2, D3, D4, D5, T](
-      ctr: (D1, D2, D3, D4, D5) => SchemaZ[P, RA, A, T]
+    def schema[A, RA, D1, D2, D3, D4, T](
+      ctr: (D1, D2, D3, D4) => SchemaZ.Aux[RA, A, T]
     )(
-      implicit add: Version.AddEntry[Types, (D1, D2, D3, D4, D5), A, RA]
-    ): Version[(Schema[A], Types), (Version.Entry.Aux[A, RA, Types], Re)] =
+      implicit add: Version.AddEntry[Types, (D1, D2, D3, D4), A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
       new Version(
         (add(Version.Entry(ctr.tupled)), registry)
       )
 
-    def migrate[A](
-      implicit lookup: Version.LookupCtr[Re, A]
-    ): Migration[Types, Re, A, lookup.Repr, lookup.Deps] = new Migration(registry, lookup)
+    def schema[A, RA, D1, D2, D3, D4, D5, T](
+      ctr: (D1, D2, D3, D4, D5) => SchemaZ.Aux[RA, A, T]
+    )(
+      implicit add: Version.AddEntry[Types, (D1, D2, D3, D4, D5), A, RA, T]
+    ): Version[(SchemaZ.Aux[RA, A, T], Types), (Version.Entry.Aux[A, T, RA, Types], Re)] =
+      new Version(
+        (add(Version.Entry(ctr.tupled)), registry)
+      )
 
-    def lookup[A](implicit l: Version.Lookup[Types, A]): Schema[A] = l(types)
+    def migrate[T](
+      implicit lookup: Version.LookupCtr[Re, T]
+    ): Migration[Types, Re, lookup.A, lookup.Repr, lookup.Deps, T] =
+      new Migration[Types, Re, lookup.A, lookup.Repr, lookup.Deps, T](registry, lookup)
+
+    def lookup[T](implicit l: Version.Lookup[Types, T]): SchemaZ.Aux[l.Repr, l.A, T] = l(types)
 
   }
 
-  final class Migration[Types, Re, A, RA, D](
+  final class Migration[Types, Re, A, RA, D, T](
     registry: Re,
-    lookup: Version.LookupCtr.Aux[Re, A, RA, D]
+    lookup: Version.LookupCtr.Aux[Re, A, RA, D, T]
   ) {
 
-    def change[RA1, Re1](migration: SchemaZ[RA, A] => SchemaZ[RA1, A])(
-      implicit replace: Version.Replace.Aux[Re, A, RA1, D, Re1],
+    def change[RA1, A1, Re1](migration: SchemaZ.Aux[RA, A, T] => SchemaZ.Aux[RA1, A1, T])(
+      implicit replace: Version.Replace.Aux[Re, A, RA, A1, RA1, D, T, Re1],
       build: Version.Build[Types, Re1]
-    ): Version[Types, Re1] =
-      new Version[Types, Re1](replace(registry, lookup(registry).post(migration)))
+    ): Version[Types, Re1] = {
+      val migrated = lookup(registry).post(migration)
+      new Version[Types, Re1](replace(registry, migrated))
+    }
   }
 
   object Version {
 
-    trait Entry[P[_, _], A, T] {
+    trait Entry[A, T] {
       type Deps
       type Repr
-      val entry: Deps => SchemaZ[P, Repr, A, T]
-      def pre[D0](f: D0 => Deps): Entry.Aux[P, A, T, Repr, D0]
-      def post[R0](f: SchemaZ[P, Repr, A, T] => SchemaZ[P, R0, A, T]): Entry.Aux[P, A, T, R0, Deps]
+      val entry: Deps => SchemaZ.Aux[Repr, A, T]
+      def pre[D0](f: D0 => Deps): Entry.Aux[A, T, Repr, D0]
+
+      def post[R1, A1](
+        f: SchemaZ.Aux[Repr, A, T] => SchemaZ.Aux[R1, A1, T]
+      ): Entry.Aux[A1, T, R1, Deps]
     }
 
     object Entry {
-      type Aux[P[_, _], A, T, RA, D] = Entry[P, A, T] { type Deps = D; type Repr = RA }
+      type Aux[A, T, RA, D] = Entry[A, T] { type Deps = D; type Repr = RA }
 
-      def apply[P[_, _], A, T, RA, D](ctr: D => SchemaZ[P, RA, A, T]): Aux[P, A, T, RA, D] =
-        VersionEntry[P, A, T, RA, D](ctr)
+      def apply[A, T, RA, D](ctr: D => SchemaZ.Aux[RA, A, T]): Aux[A, T, RA, D] =
+        VersionEntry[A, T, RA, D](ctr)
     }
-    case class VersionEntry[P[_, _], A, T, RA, D](entry: D => SchemaZ[P, RA, A, T])
-        extends Entry[P, A, T] {
+    case class VersionEntry[A, T, RA, D](entry: D => SchemaZ.Aux[RA, A, T]) extends Entry[A, T] {
       type Deps = D
       type Repr = RA
 
-      def pre[D0](f: D0 => Deps): Entry.Aux[P, A, T, Repr, D0] = Entry(entry.compose(f))
+      def pre[D0](f: D0 => Deps): Entry.Aux[A, T, Repr, D0] = Entry(entry.compose(f))
 
-      def post[R0](
-        f: SchemaZ[P, Repr, A, T] => SchemaZ[P, R0, A, T]
-      ): Entry.Aux[P, A, T, R0, Deps] =
+      def post[R1, A1](
+        f: SchemaZ.Aux[Repr, A, T] => SchemaZ.Aux[R1, A1, T]
+      ): Entry.Aux[A1, T, R1, Deps] =
         Entry(entry.andThen(f))
 
     }
 
-    trait AddEntry[P[_, _], Re, D, A, RA, T] {
+    trait AddEntry[Re, D, A, RA, T] {
       def prepare: Re => D
 
       def apply(
-        newEntry: Version.Entry.Aux[P, A, T, RA, D]
-      ): Version.Entry.Aux[P, A, T, RA, Re] =
+        newEntry: Version.Entry.Aux[A, T, RA, D]
+      ): Version.Entry.Aux[A, T, RA, Re] =
         newEntry.pre(prepare)
     }
 
     object AddEntry {
 
-      implicit def noDependencies[P[_, _], Re, A, RA, T]: AddEntry[P, Re, Unit, A, RA, T] =
-        new AddEntry[P, Re, Unit, A, RA, T] { def prepare: Re => Unit = _ => () }
+      implicit def noDependencies[Re, A, RA, T]: AddEntry[Re, Unit, A, RA, T] =
+        new AddEntry[Re, Unit, A, RA, T] { def prepare: Re => Unit = _ => () }
 
-      implicit def singleDependency[P[_, _], Re, D, A, RA, T](
+      implicit def singleDependency[Re, D, A, RA, T](
         implicit D: Version.Lookup[Re, D]
-      ): AddEntry[P, Re, Schema[D], A, RA, T] = new AddEntry[P, Re, Schema[D], A, RA, T] {
-        def prepare: Re => Schema[D] = (re => D(re))
+      ): AddEntry[Re, SchemaZ[D], A, RA, T] = new AddEntry[Re, SchemaZ[D], A, RA, T] {
+        def prepare: Re => SchemaZ[D] = (re => D(re))
       }
 
-      implicit def twoDependencies[Re, D1, D2, A, RA](
+      implicit def twoDependencies[Re, D1, D2, A, RA, T](
         implicit D1: Version.Lookup[Re, D1],
         D2: Version.Lookup[Re, D2]
-      ): AddEntry[Re, (Schema[D1], Schema[D2]), A, RA] =
-        new AddEntry[Re, (Schema[D1], Schema[D2]), A, RA] {
-          def prepare: Re => (Schema[D1], Schema[D2]) = (re => (D1(re), D2(re)))
+      ): AddEntry[Re, (SchemaZ[D1], SchemaZ[D2]), A, RA, T] =
+        new AddEntry[Re, (SchemaZ[D1], SchemaZ[D2]), A, RA, T] {
+          def prepare: Re => (SchemaZ[D1], SchemaZ[D2]) = (re => (D1(re), D2(re)))
         }
 
-      implicit def threeDependencies[Re, D1, D2, D3, A, RA](
+      implicit def threeDependencies[Re, D1, D2, D3, A, RA, T](
         implicit D1: Version.Lookup[Re, D1],
         D2: Version.Lookup[Re, D2],
         D3: Version.Lookup[Re, D3]
-      ): AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3]), A, RA] =
-        new AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3]), A, RA] {
-          def prepare: Re => (Schema[D1], Schema[D2], Schema[D3]) = (re => (D1(re), D2(re), D3(re)))
+      ): AddEntry[Re, (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3]), A, RA, T] =
+        new AddEntry[Re, (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3]), A, RA, T] {
+
+          def prepare: Re => (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3]) =
+            (re => (D1(re), D2(re), D3(re)))
         }
 
-      implicit def fourDependencies[Re, D1, D2, D3, D4, A, RA](
+      implicit def fourDependencies[Re, D1, D2, D3, D4, A, RA, T](
         implicit D1: Version.Lookup[Re, D1],
         D2: Version.Lookup[Re, D2],
         D3: Version.Lookup[Re, D3],
         D4: Version.Lookup[Re, D4]
-      ): AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3], Schema[D4]), A, RA] =
-        new AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3], Schema[D4]), A, RA] {
+      ): AddEntry[Re, (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4]), A, RA, T] =
+        new AddEntry[Re, (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4]), A, RA, T] {
 
-          def prepare: Re => (Schema[D1], Schema[D2], Schema[D3], Schema[D4]) =
+          def prepare: Re => (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4]) =
             (re => (D1(re), D2(re), D3(re), D4(re)))
         }
 
-      implicit def fiveDependencies[Re, D1, D2, D3, D4, D5, A, RA](
+      implicit def fiveDependencies[Re, D1, D2, D3, D4, D5, A, RA, T](
         implicit D1: Version.Lookup[Re, D1],
         D2: Version.Lookup[Re, D2],
         D3: Version.Lookup[Re, D3],
         D4: Version.Lookup[Re, D4],
         D5: Version.Lookup[Re, D5]
-      ): AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3], Schema[D4], Schema[D5]), A, RA] =
-        new AddEntry[Re, (Schema[D1], Schema[D2], Schema[D3], Schema[D4], Schema[D5]), A, RA] {
+      ): AddEntry[
+        Re,
+        (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4], SchemaZ[D5]),
+        A,
+        RA,
+        T
+      ] =
+        new AddEntry[
+          Re,
+          (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4], SchemaZ[D5]),
+          A,
+          RA,
+          T
+        ] {
 
-          def prepare: Re => (Schema[D1], Schema[D2], Schema[D3], Schema[D4], Schema[D5]) =
+          def prepare: Re => (SchemaZ[D1], SchemaZ[D2], SchemaZ[D3], SchemaZ[D4], SchemaZ[D5]) =
             (re => (D1(re), D2(re), D3(re), D4(re), D5(re)))
         }
     }
 
-    trait LookupCtr[Re, A] {
+    trait LookupCtr[Re, T] {
       type Repr
       type Deps
-      def apply(registry: Re): Version.Entry.Aux[A, Repr, Deps]
+      type A
+      def apply(registry: Re): Version.Entry.Aux[A, T, Repr, Deps]
     }
 
     trait LowPrioLookupCtr {
-      implicit def tailLookupCtr[R1, RT, A, R0, D0](
-        implicit rest: LookupCtr.Aux[RT, A, R0, D0]
-      ): LookupCtr.Aux[(R1, RT), A, R0, D0] =
-        new LookupCtr[(R1, RT), A] {
+      implicit def tailLookupCtr[R1, RT, A0, R0, D0, T](
+        implicit rest: LookupCtr.Aux[RT, A0, R0, D0, T]
+      ): LookupCtr.Aux[(R1, RT), A0, R0, D0, T] =
+        new LookupCtr[(R1, RT), T] {
+
           type Repr = R0
           type Deps = D0
-          def apply(registry: (R1, RT)): Version.Entry.Aux[A, R0, D0] = rest(registry._2)
+          type A    = A0
+          def apply(registry: (R1, RT)): Version.Entry.Aux[A0, T, R0, D0] = rest(registry._2)
         }
     }
 
     object LookupCtr extends LowPrioLookupCtr {
-      type Aux[Re, A, R0, D0] = LookupCtr[Re, A] { type Repr = R0; type Deps = D0 }
-      implicit def headLookupCtr[RR, A, R0, D]
-        : LookupCtr.Aux[(Version.Entry.Aux[A, R0, D], RR), A, R0, D] =
-        new LookupCtr[(Version.Entry.Aux[A, R0, D], RR), A] {
+
+      type Aux[Re, A0, R0, D0, T] = LookupCtr[Re, T] {
+        type Repr = R0; type Deps = D0; type A = A0
+      }
+
+      implicit def headLookupCtr[RR, A0, R0, D, T]
+        : LookupCtr.Aux[(Version.Entry.Aux[A0, T, R0, D], RR), A0, R0, D, T] =
+        new LookupCtr[(Version.Entry.Aux[A0, T, R0, D], RR), T] {
+
           type Repr = R0
           type Deps = D
+          type A    = A0
 
           def apply(
-            registry: (Version.Entry.Aux[A, R0, D], RR)
-          ): Version.Entry.Aux[A, R0, D] =
+            registry: (Version.Entry.Aux[A0, T, R0, D], RR)
+          ): Version.Entry.Aux[A0, T, R0, D] =
             registry._1
         }
     }
 
-    trait Replace[Re, A, R1, D] {
+    trait Replace[Re, A0, R0, A1, R1, D, T] {
       type Out
-      def apply(registry: Re, replacement: Version.Entry.Aux[A, R1, D]): Out
+      def apply(registry: Re, replacement: Version.Entry.Aux[A1, T, R1, D]): Out
     }
 
     object Replace {
 
-      type Aux[Re, A, R1, D, Re1] = Replace[Re, A, R1, D] { type Out = Re1 }
+      type Aux[Re, A0, R0, A1, R1, D, T, Re1] = Replace[Re, A0, R0, A1, R1, D, T] {
+        type Out = Re1
+      }
 
-      implicit def tailReplace[A, RA, RA1, D, RT]: Replace.Aux[
-        (Version.Entry.Aux[A, RA, D], RT),
-        A,
-        RA1,
+      implicit def tailReplace[A0, R0, A1, R1, D, RT, T]: Replace.Aux[
+        (Version.Entry.Aux[A0, T, R0, D], RT),
+        A0,
+        R0,
+        A1,
+        R1,
         D,
-        (Version.Entry.Aux[A, RA1, D], RT)
+        T,
+        (Version.Entry.Aux[A1, T, R1, D], RT)
       ] =
-        new Replace[(Version.Entry.Aux[A, RA, D], RT), A, RA1, D] {
-          type Out = (Version.Entry.Aux[A, RA1, D], RT)
+        new Replace[(Version.Entry.Aux[A0, T, R0, D], RT), A0, R0, A1, R1, D, T] {
+          type Out = (Version.Entry.Aux[A1, T, R1, D], RT)
           override def apply(
-            registry: (Version.Entry.Aux[A, RA, D], RT),
-            replacement: Version.Entry.Aux[A, RA1, D]
-          ): (Version.Entry.Aux[A, RA1, D], RT) = (replacement, registry._2)
+            registry: (Version.Entry.Aux[A0, T, R0, D], RT),
+            replacement: Version.Entry.Aux[A1, T, R1, D]
+          ): (Version.Entry.Aux[A1, T, R1, D], RT) = (replacement, registry._2)
         }
 
-      implicit def headReplace[H, A, R1, D, RT, RT1](
-        implicit rest: Replace.Aux[RT, A, R1, D, RT1]
-      ): Replace.Aux[(H, RT), A, R1, D, (H, RT1)] =
-        new Replace[(H, RT), A, R1, D] {
+      implicit def headReplace[H, A0, R0, A1, R1, D, RT, RT1, T](
+        implicit rest: Replace.Aux[RT, A0, R0, A1, R1, D, T, RT1]
+      ): Replace.Aux[(H, RT), A0, R0, A1, R1, D, T, (H, RT1)] =
+        new Replace[(H, RT), A0, R0, A1, R1, D, T] {
           type Out = (H, RT1)
           override def apply(
             registry: (H, RT),
-            replacement: Version.Entry.Aux[A, R1, D]
+            replacement: Version.Entry.Aux[A1, T, R1, D]
           ): (H, RT1) =
             (registry._1, rest(registry._2, replacement))
         }
@@ -243,14 +280,14 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
         def apply(ctrReg: Unit): Unit = ctrReg
       }
 
-      implicit def buildVersion[A, Tpe, Reg, RA](
+      implicit def buildVersion[A, T, Tpe, Reg, RA](
         implicit rest: Build[Tpe, Reg]
-      ): Build[(Schema[A], Tpe), (Version.Entry.Aux[A, RA, Tpe], Reg)] =
-        new Build[(Schema[A], Tpe), (Version.Entry.Aux[A, RA, Tpe], Reg)] {
+      ): Build[(SchemaZ.Aux[RA, A, T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] =
+        new Build[(SchemaZ.Aux[RA, A, T], Tpe), (Version.Entry.Aux[A, T, RA, Tpe], Reg)] {
 
           def apply(
-            ctrReg: (Version.Entry.Aux[A, RA, Tpe], Reg)
-          ): (Schema[A], Tpe) = {
+            ctrReg: (Version.Entry.Aux[A, T, RA, Tpe], Reg)
+          ): (SchemaZ.Aux[RA, A, T], Tpe) = {
             val tail = rest(ctrReg._2)
 
             (ctrReg._1.entry(tail), tail)
@@ -258,21 +295,39 @@ trait Versioning[R <: Realisation] extends SchemaModule[R] {
         }
     }
 
-    trait Lookup[Re, A] {
-      def apply(registry: Re): Schema[A]
+    trait Lookup[Re, T] {
+
+      type A
+      type Repr
+      def apply(registry: Re): SchemaZ.Aux[Repr, A, T]
     }
 
     trait LowPrioLookup {
-      implicit def tailLookup[R1, RT, A](implicit rest: Lookup[RT, A]): Lookup[(R1, RT), A] =
-        new Lookup[(R1, RT), A] {
-          def apply(registry: (R1, RT)): Schema[A] = rest(registry._2)
+      implicit def tailLookup[R1, RT, T](
+        implicit rest: Lookup[RT, T]
+      ): Lookup.Aux[(R1, RT), T, rest.Repr, rest.A] =
+        new Lookup[(R1, RT), T] {
+
+          type A    = rest.A
+          type Repr = rest.Repr
+          def apply(registry: (R1, RT)): SchemaZ.Aux[rest.Repr, rest.A, T] = rest(registry._2)
         }
     }
 
     object Lookup extends LowPrioLookup {
-      implicit def headLookup[RR, A]: Lookup[(Schema[A], RR), A] =
-        new Lookup[(Schema[A], RR), A] {
-          def apply(registry: (Schema[A], RR)): Schema[A] = registry._1
+
+      type Aux[Re, T, R0, A0] = Lookup[Re, T] {
+        type A = A0; type Repr = R0
+      }
+
+      implicit def headLookup[RR, R0, A0, T]: Lookup.Aux[(SchemaZ.Aux[R0, A0, T], RR), T, R0, A0] =
+        new Lookup[(SchemaZ.Aux[R0, A0, T], RR), T] {
+
+          type A    = A0
+          type Repr = R0
+
+          def apply(registry: (SchemaZ.Aux[R0, A0, T], RR)): SchemaZ.Aux[R0, A0, T] =
+            registry._1
         }
     }
 

--- a/modules/generic/src/main/scala/GenericAlgebra.scala
+++ b/modules/generic/src/main/scala/GenericAlgebra.scala
@@ -24,7 +24,6 @@ trait GenericSchemaModule[R <: Realisation] extends SchemaModule[R] {
           case PrimSchemaF(prim)         => primNT(prim)
           case x: Sum[H, a, b]           => H.either2(x.left, x.right)
           case x: Prod[H, a, b]          => H.tuple2(x.left, x.right)
-          case x: IsoSchema[H, a0, a]    => H.map(x.base)(x.iso.get)
           case x: Record[H, a]           => x.fields
           case x: Sequence[H, a]         => seqNT(x.element)
           case pt: Field[H, a]           => prodLabelNT(pt)
@@ -46,15 +45,9 @@ trait GenericSchemaModule[R <: Realisation] extends SchemaModule[R] {
 
       def apply[A](schema: RSchema[H, A]): H[A] =
         schema match {
-          case PrimSchemaF(prim) => primNT(prim)
-          case x: Prod[H, a, b]  => H.divide(x.left, x.right)(identity[(a, b)])
-          case x: Sum[H, a, b]   => H.choose(x.left, x.right)(identity[a \/ b])
-          //UHOH THOSE BOTH COMPILE?! (for the love of all that is precious to you, please leave the pattern matches that actually bind the type variables)
-          //case IsoSchema(base, iso)      => H.contramap(base)(iso.get)
-          //case IsoSchema(base, iso)      => H.contramap(base)(iso.reverseGet)
-          //Luckily does not compile
-          //case x: IsoSchema[_, a, a0]    => H.contramap(x.base)(x.iso.get)
-          case x: IsoSchema[H, a, a0]    => H.contramap(x.base)(x.iso.reverseGet)
+          case PrimSchemaF(prim)         => primNT(prim)
+          case x: Prod[H, a, b]          => H.divide(x.left, x.right)(identity[(a, b)])
+          case x: Sum[H, a, b]           => H.choose(x.left, x.right)(identity[a \/ b])
           case x: Record[H, a]           => x.fields
           case x: Sequence[H, a]         => seqNT(x.element)
           case pt: Field[H, a]           => prodLabelNT(pt)

--- a/modules/generic/src/main/scala/ShowModule.scala
+++ b/modules/generic/src/main/scala/ShowModule.scala
@@ -7,6 +7,10 @@ import recursion._
 
 trait ShowModule[R <: Realisation] extends GenericSchemaModule[R] {
 
+  implicit object ShowTransform extends Transform[Show] {
+    def apply[A, B](fa: Show[A], p: NIso[A, B]): Show[B] = Show.showContravariant.contramap(fa)(p.g)
+  }
+
   implicit val showDecidableInstance: Decidable[Show] = new Decidable[Show] {
     override def choose2[Z, A1, A2](a1: => Show[A1], a2: => Show[A2])(f: Z => A1 \/ A2): Show[Z] =
       Show.shows[Z](z => f(z).fold(a1.shows, a2.shows))

--- a/modules/play-json/src/main/scala/PlayJsonModule.scala
+++ b/modules/play-json/src/main/scala/PlayJsonModule.scala
@@ -72,6 +72,10 @@ trait PlayJsonModule[R <: Realisation] extends SchemaModule[R] {
         (false, fSchema)
     }
 
+  implicit object ReadsTransform extends Transform[Reads] {
+    def apply[A, B](fa: Reads[A], p: NIso[A, B]): Reads[B] = fa.map(p.f)
+  }
+
   implicit final def readsInterpreter(
     implicit primNT: R.Prim ~> Reads,
     branchLabel: R.SumTermId <~< String,
@@ -127,6 +131,10 @@ trait PlayJsonModule[R <: Realisation] extends SchemaModule[R] {
         }
       )
       .compose(labellingSeed)
+
+  implicit object WritesTransform extends Transform[Writes] {
+    def apply[A, B](fa: Writes[A], p: NIso[A, B]): Writes[B] = fa.contramap(p.g)
+  }
 
   implicit final def writesInterpreter(
     implicit primNT: R.Prim ~> Writes,

--- a/modules/play-json/src/main/scala/PlayJsonModule.scala
+++ b/modules/play-json/src/main/scala/PlayJsonModule.scala
@@ -122,8 +122,6 @@ trait PlayJsonModule[R <: Realisation] extends SchemaModule[R] {
                   elems.toList.traverse(elem.reads _)
                 case _ => JsError(Seq(JsPath -> Seq(JsonValidationError("error.expected.jsarray"))))
               }
-            case i: IsoSchema[Reads, a0, A] =>
-              i.base.map(i.iso.get)
             case ref @ SelfReference(_, _) => Reads(ref.unroll.reads)
           }
         }
@@ -157,14 +155,13 @@ trait PlayJsonModule[R <: Realisation] extends SchemaModule[R] {
                 Writes(
                   pair => Json.obj("_1" -> left.writes(pair._1), "_2" -> right.writes(pair._2))
                 )
-            case PrimSchemaF(p)             => primNT(p)
-            case BranchF(id, s)             => Writes(a => Json.obj(branchLabel(id) -> s.writes(a)))
-            case u: Union[Writes, a]        => u.choices
-            case FieldF(id, s)              => Writes(a => Json.obj(fieldLabel(id) -> s.writes(a)))
-            case r: Record[Writes, a]       => r.fields
-            case SeqF(elem)                 => Writes(seq => JsArray(seq.map(elem.writes(_))))
-            case i: IsoSchema[Writes, a, A] => i.base.contramap(i.iso.reverseGet)
-            case ref @ SelfReference(_, _)  => Writes(ref.unroll.writes)
+            case PrimSchemaF(p)            => primNT(p)
+            case BranchF(id, s)            => Writes(a => Json.obj(branchLabel(id) -> s.writes(a)))
+            case u: Union[Writes, a]       => u.choices
+            case FieldF(id, s)             => Writes(a => Json.obj(fieldLabel(id) -> s.writes(a)))
+            case r: Record[Writes, a]      => r.fields
+            case SeqF(elem)                => Writes(seq => JsArray(seq.map(elem.writes(_))))
+            case ref @ SelfReference(_, _) => Writes(ref.unroll.writes)
           }
 
         }

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -21,7 +21,6 @@ trait GenModule[R <: Realisation] extends SchemaModule[R] {
               r <- right
             } yield (l, r)
           case SumF(left, right)         => Gen.oneOf(left.map(-\/(_)), right.map(\/-(_)))
-          case IsoSchemaF(base, iso)     => base.map(iso.get)
           case RecordF(fields)           => fields
           case SeqF(element)             => Gen.listOf(element)
           case FieldF(_, base)           => base

--- a/modules/scalacheck/src/main/scala/GenModule.scala
+++ b/modules/scalacheck/src/main/scala/GenModule.scala
@@ -7,6 +7,10 @@ import scalaz.{ -\/, \/-, ~> }
 
 trait GenModule[R <: Realisation] extends SchemaModule[R] {
 
+  implicit object GenTransform extends Transform[Gen] {
+    def apply[A, B](fa: Gen[A], p: NIso[A, B]): Gen[B] = fa.map(p.f)
+  }
+
   implicit final def genInterpreter(
     implicit primNT: R.Prim ~> Gen
   ): RInterpreter[Gen] =

--- a/modules/tests/src/main/scala/GenModuleExamples.scala
+++ b/modules/tests/src/main/scala/GenModuleExamples.scala
@@ -58,7 +58,7 @@ object GenModuleExamples {
       test("Convert Schema to Gen with Generic Module") { () =>
         val module = new TestModule with GenericGenModule[JsonSchema.type] with PrimToGen {}
         import module._
-        val personGen: Gen[PersonTuple] = module.current.lookup[PersonTuple].to[Gen]
+        val personGen: Gen[Person] = module.current.lookup[Person].to[Gen]
 
         val prop = forAll {
           (seed1: Long, seed2: Long) =>

--- a/modules/tests/src/main/scala/GenModuleExamples.scala
+++ b/modules/tests/src/main/scala/GenModuleExamples.scala
@@ -29,7 +29,7 @@ object GenModuleExamples {
         val module = new TestModule with GenModule[JsonSchema.type] with PrimToGen {}
         import module._
 
-        val personGen: Gen[PersonTuple] = module.current.lookup[PersonTuple].to[Gen]
+        val personGen: Gen[Person] = module.current.lookup[Person].to[Gen]
 
         val prop = forAll {
           (seed1: Long, seed2: Long) =>

--- a/modules/tests/src/main/scala/GenericGenModule.scala
+++ b/modules/tests/src/main/scala/GenericGenModule.scala
@@ -22,6 +22,10 @@ trait GenericGenModule[R <: Realisation] extends GenericSchemaModule[R] {
 
   }
 
+  implicit object GenTransform extends Transform[Gen] {
+    def apply[A, B](fa: Gen[A], p: NIso[A, B]): Gen[B] = fa.map(p.f)
+  }
+
   implicit final def genericGenInterpreter(
     implicit primNT: R.Prim ~> Gen
   ): RInterpreter[Gen] = Interpreter.cata(

--- a/modules/tests/src/main/scala/JsonExamples.scala
+++ b/modules/tests/src/main/scala/JsonExamples.scala
@@ -36,7 +36,7 @@ object JsonExamples {
 
 //        type PersonTuple = (Seq[Char], Option[Role])
 
-        val isoSerializer = personTupleSchema.to[Encoder]
+        //val isoSerializer = personTupleSchema.to[Encoder]
 
         val boss = Person("Alfred", None)
 
@@ -51,35 +51,37 @@ object JsonExamples {
           (res, testCase) =>
             (res, testCase) match {
               case (Succeed, (data, expected)) => {
-                val json    = serializer(data)
-                val isoJson = isoSerializer(Person.personToTupleIso.reverse(data))
+                val json = serializer(data)
+                //  val isoJson = isoSerializer(Person.personToTupleIso.reverse(data))
 
-                val same    = matchJsonStrings(json, expected)
-                val isoSame = matchJsonStrings(isoJson, expected)
+                val same = matchJsonStrings(json, expected)
+                // val isoSame = matchJsonStrings(isoJson, expected)
 
-                val res =
-                  if (same) Succeed else Fail(List(Right(s"got $json expected $expected")))
-                val isoRes =
+                //val res =
+                if (same) Succeed else Fail(List(Right(s"got $json expected $expected")))
+                /* val isoRes =
                   if (isoSame) Succeed
                   else Fail(List(Right(s"got $isoJson expected $expected")))
 
                 Result.combine(res, isoRes)
+               */
               }
 
               case (fail: testz.Fail, (data, expected)) => {
-                val json    = serializer(data)
-                val isoJson = isoSerializer(Person.personToTupleIso.reverse(data))
-                val same    = matchJsonStrings(json, expected)
-                val isoSame = matchJsonStrings(isoJson, expected)
+                val json = serializer(data)
+                //val isoJson = isoSerializer(Person.personToTupleIso.reverse(data))
+                val same = matchJsonStrings(json, expected)
+                //val isoSame = matchJsonStrings(isoJson, expected)
 
-                val res =
-                  if (same) fail
-                  else Fail(Right(s"got $json expected $expected") :: fail.failures)
-                val isoRes =
+                //val res =
+                if (same) fail
+                else Fail(Right(s"got $json expected $expected") :: fail.failures)
+                /*val isoRes =
                   if (isoSame) fail
                   else Fail(Right(s"got $isoJson expected $expected") :: fail.failures)
 
                 Result.combine(res, isoRes)
+               */
               }
 
             }

--- a/modules/tests/src/main/scala/MigrationExamples.scala
+++ b/modules/tests/src/main/scala/MigrationExamples.scala
@@ -55,7 +55,7 @@ object MigrationExamples {
 
     val personV0 = caseClass(
       "role" -*>: optional(current.lookup[Role]),
-      Iso[Option[Role], PersonV0](PersonV0.apply)(p => p.role)
+      NIso[Option[Role], PersonV0](PersonV0.apply, p => p.role)
     )
 
     section("Migrating schema")(

--- a/modules/tests/src/main/scala/MigrationExamples.scala
+++ b/modules/tests/src/main/scala/MigrationExamples.scala
@@ -3,7 +3,6 @@ package schemaz
 package tests
 
 import scalaz.~>
-import monocle.Iso
 import testz._
 import scalacheck.GenModule
 import org.scalacheck._, Prop._, Arbitrary._

--- a/modules/tests/src/main/scala/Person.scala
+++ b/modules/tests/src/main/scala/Person.scala
@@ -16,7 +16,7 @@ object Person {
   private def f(p: Person): (Seq[Char], Option[Role]) = (p.name.toSeq, p.role)
   private def g(t: (Seq[Char], Option[Role])): Person = Person(t._1.mkString, t._2)
 
-  val personToTupleIso = Iso[Person, (Seq[Char], Option[Role])](f)(g)
+  val personToTupleIso = NIso[Person, (Seq[Char], Option[Role])](f, g)
 }
 
 trait TestModule extends SchemaModule[JsonSchema.type] with Versioning[JsonSchema.type] {
@@ -28,47 +28,47 @@ trait TestModule extends SchemaModule[JsonSchema.type] with Versioning[JsonSchem
     .schema(
       caseClass(
         "active".narrow -*>: prim(JsonSchema.JsonBool),
-        Iso[Boolean, User](User.apply)(u => u.active)
+        NIso[Boolean, User](User.apply, u => u.active)
       )
     )
     .schema(
       caseClass(
         "rights".narrow -*>: seq(prim(JsonSchema.JsonString)),
-        Iso[List[String], Admin](Admin.apply)(_.rights)
+        NIso[List[String], Admin](Admin.apply, _.rights)
       )
     )
     .schema(
-      (u: Schema[User], a: Schema[Admin]) =>
+      (u: SchemaZ[User], a: SchemaZ[Admin]) =>
         sealedTrait(
           "user".narrow -+>: u :+:
             "admin".narrow -+>: a,
-          Iso[User \/ Admin, Role] {
+          NIso[User \/ Admin, Role]({
             case -\/(u) => u
             case \/-(a) => a
-          } {
+          }, {
             case u @ User(_)  => -\/(u)
             case a @ Admin(_) => \/-(a)
-          }
+          })
         )
     )
     .schema(
-      (r: Schema[Role]) =>
+      (r: SchemaZ[Role]) =>
         caseClass(
           "name".narrow -*>: prim(JsonSchema.JsonString) :*:
             "role".narrow -*>: optional(
             r
           ),
-          Iso[(String, Option[Role]), Person]((Person.apply _).tupled)(p => (p.name, p.role))
+          NIso[(String, Option[Role]), Person]((Person.apply _).tupled, p => (p.name, p.role))
         )
     )
-    .schema(
-      (p: Schema[Person]) =>
-        iso(
-          SchemaZ[Person, Person](p),
+  /*.schema(
+      (p: SchemaZ[Person]) =>
+        iso[Person, PersonTuple](
+          p,
           Person.personToTupleIso
         )
     )
-
-  val person            = current.lookup[Person]
-  val personTupleSchema = current.lookup[PersonTuple]
+   */
+  val person = current.lookup[Person]
+  // val personTupleSchema = current.lookup[PersonTuple]
 }

--- a/modules/tests/src/main/scala/SchemaModuleExamples.scala
+++ b/modules/tests/src/main/scala/SchemaModuleExamples.scala
@@ -25,13 +25,10 @@ object SchemaModuleExamples {
 
         val adminSchema = caseClass(
           adminRecord,
-          Iso[List[String], Admin](Admin.apply)(_.rights)
+          NIso[List[String], Admin](Admin.apply, _.rights)
         )
 
-        adminSchema.imap(adminToListIso).imap(listToSeqIso).unFix match {
-          case IsoSchemaF(base, _) => assert(base == record(adminRecord))
-          case _                   => assert(false)
-        }
+        assert(adminSchema.schema == adminRecord.schema)
       }
     )
   }

--- a/modules/tests/src/main/scala/SchemaModuleExamples.scala
+++ b/modules/tests/src/main/scala/SchemaModuleExamples.scala
@@ -2,7 +2,6 @@ package schemaz
 
 package tests
 
-import monocle.Iso
 import testz._
 
 object SchemaModuleExamples {
@@ -18,8 +17,8 @@ object SchemaModuleExamples {
 
     section("Manipulating Schemas")(
       test("imap on IsoSchema shouldn't add new layer") { () =>
-        val adminToListIso  = Iso[Admin, List[String]](_.rights)(Admin.apply)
-        def listToSeqIso[A] = Iso[List[A], Seq[A]](_.toSeq)(_.toList)
+        //val adminToListIso  = NIso[Admin, List[String]](_.rights, Admin.apply)
+        //def listToSeqIso[A] = NIso[List[A], Seq[A]](_.toSeq, _.toList)
 
         val adminRecord = "rights" -*>: seq(prim(JsonSchema.JsonString))
 
@@ -28,7 +27,7 @@ object SchemaModuleExamples {
           NIso[List[String], Admin](Admin.apply, _.rights)
         )
 
-        assert(adminSchema.schema == adminRecord.schema)
+        assert(adminSchema.schema == record(adminRecord).schema)
       }
     )
   }


### PR DESCRIPTION
This PR changes the encoding once again, and simplifies things a bit. The main changes are:

- the `IsoSchema` case of `SchemaF` has been deleted
- `SchemaZ` now carries an iso from `Repr` (the concrete representation of the subject type in terms of "sum of products") to `A` (the subject type that is represented by this `SchemaZ`).

So now, a `SchemaZ` is composed of a "simple" structure (a `Fix[SchemaF]`) that represents the subject type in terms of "sum of products" and an isomorphism from this representation to the subject type itself.